### PR TITLE
feat: add reset-credentials to long loving instance test

### DIFF
--- a/src/main/java/io/managed/services/test/Environment.java
+++ b/src/main/java/io/managed/services/test/Environment.java
@@ -98,8 +98,6 @@ public class Environment {
     public static final String SERVICE_API_URI = getOrDefault(SERVICE_API_URI_ENV, "https://api.stage.openshift.com");
 
     public static final String KAFKA_POSTFIX_NAME = getOrDefault(KAFKA_POSTFIX_NAME_ENV, "auto-test");
-    public static final String LONG_LIVED_KAFKA_NAME = getOrDefault(LONG_LIVED_KAFKA_NAME_ENV, "mk-e2e-longlive-test");
-    public static final String LONG_LIVED_KAFKA_TOPIC_NAME = getOrDefault(LONG_LIVED_KAFKA_TOPIC_NAME_ENV, "long-live-test-topic");
 
     public static final String DEV_CLUSTER_SERVER = getOrDefault(DEV_CLUSTER_SERVER_ENV, "https://api.devexp.imkr.s1.devshift.org:6443");
     public static final String DEV_CLUSTER_NAMESPACE = getOrDefault(DEV_CLUSTER_NAMESPACE_ENV, "mk-e2e-tests");

--- a/src/main/java/io/managed/services/test/client/kafka/KafkaUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafka/KafkaUtils.java
@@ -2,15 +2,20 @@ package io.managed.services.test.client.kafka;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 
 public class KafkaUtils {
+    private static final Logger LOGGER = LogManager.getLogger(KafkaUtils.class);
 
     static public Map<String, String> configs(String bootstrapHost, String clientID, String clientSecret) {
         Map<String, String> config = new HashMap<>();
@@ -46,4 +51,13 @@ public class KafkaUtils {
         return promise.future();
     }
 
+    static public Future<Optional<TopicDescription>> getTopicByName(KafkaAdmin admin, String name) {
+        return toVertxFuture(admin.getMapOfTopicNameAndDescriptionByName(name))
+                .map(r -> r.get(name))
+                .recover(t -> {
+                    LOGGER.error("topic not found:", t);
+                    return Future.succeededFuture(null);
+                })
+                .map(Optional::ofNullable);
+    }
 }

--- a/src/main/java/io/managed/services/test/client/serviceapi/ServiceAPI.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/ServiceAPI.java
@@ -85,6 +85,14 @@ public class ServiceAPI extends BaseVertxClient {
                 .map(r -> r.bodyAsJson(ServiceAccountList.class)));
     }
 
+    public Future<ServiceAccount> resetCredentialsServiceAccount(String id) {
+        return retry(() -> client.post(String.format("/api/managed-services-api/v1/serviceaccounts/%s/reset-credentials", id))
+                .authentication(token)
+                .send()
+                .compose(r -> assertResponse(r, HttpURLConnection.HTTP_OK))
+                .map(r -> r.bodyAsJson(ServiceAccount.class)));
+    }
+
     public Future<Void> deleteServiceAccount(String id) {
         return retry(() -> client.delete(String.format("/api/managed-services-api/v1/serviceaccounts/%s", id))
                 .authentication(token)

--- a/src/test/java/io/managed/services/test/BindingOperatorTest.java
+++ b/src/test/java/io/managed/services/test/BindingOperatorTest.java
@@ -52,6 +52,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class BindingOperatorTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(BindingOperatorTest.class);
 
+    // ust the kafka long living instance
+    static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
+
     User user;
 
     ServiceAPI api;
@@ -71,10 +74,10 @@ public class BindingOperatorTest extends TestBase {
         assumeTrue(Environment.DEV_CLUSTER_TOKEN != null, "the DEV_CLUSTER_TOKEN env is null");
 
         KeycloakOAuth auth = new KeycloakOAuth(vertx,
-            Environment.SSO_REDHAT_KEYCLOAK_URI,
-            Environment.SSO_REDHAT_REDIRECT_URI,
-            Environment.SSO_REDHAT_REALM,
-            Environment.SSO_REDHAT_CLIENT_ID);
+                Environment.SSO_REDHAT_KEYCLOAK_URI,
+                Environment.SSO_REDHAT_REDIRECT_URI,
+                Environment.SSO_REDHAT_REALM,
+                Environment.SSO_REDHAT_CLIENT_ID);
 
         LOGGER.info("authenticate user: {} against: {}", Environment.SSO_USERNAME, Environment.SSO_REDHAT_KEYCLOAK_URI);
         this.user = await(auth.login(Environment.SSO_USERNAME, Environment.SSO_PASSWORD));
@@ -82,10 +85,10 @@ public class BindingOperatorTest extends TestBase {
 
 
         Config config = new ConfigBuilder()
-            .withMasterUrl(Environment.DEV_CLUSTER_SERVER)
-            .withOauthToken(Environment.DEV_CLUSTER_TOKEN)
-            .withNamespace(Environment.DEV_CLUSTER_NAMESPACE)
-            .build();
+                .withMasterUrl(Environment.DEV_CLUSTER_SERVER)
+                .withOauthToken(Environment.DEV_CLUSTER_TOKEN)
+                .withNamespace(Environment.DEV_CLUSTER_NAMESPACE)
+                .build();
 
         LOGGER.info("initialize kubernetes client");
         this.client = new DefaultKubernetesClient(config);
@@ -159,8 +162,7 @@ public class BindingOperatorTest extends TestBase {
         a = OperatorUtils.managedServiceAccountRequest(client).create(a);
         LOGGER.info("created ManagedServiceAccountRequest: {}", Json.encode(a));
 
-        IsReady<ManagedServiceAccountRequest> ready = last ->
-            Future.succeededFuture(OperatorUtils.managedServiceAccountRequest(client).withName(MANAGED_SERVICE_ACCOUNT_REQUEST_NAME).get())
+        IsReady<ManagedServiceAccountRequest> ready = last -> Future.succeededFuture(OperatorUtils.managedServiceAccountRequest(client).withName(MANAGED_SERVICE_ACCOUNT_REQUEST_NAME).get())
                 .map(r -> {
 
                     LOGGER.info("ManagedServiceAccountRequest status is: {}", Json.encode(r.getStatus()));
@@ -192,8 +194,7 @@ public class BindingOperatorTest extends TestBase {
         k = OperatorUtils.managedServicesRequest(client).create(k);
         LOGGER.info("created ManagedServicesRequest: {}", Json.encode(k));
 
-        IsReady<ManagedServicesRequest> ready = last ->
-            Future.succeededFuture(OperatorUtils.managedServicesRequest(client).withName(MANAGED_KAFKA_REQUEST_NAME).get())
+        IsReady<ManagedServicesRequest> ready = last -> Future.succeededFuture(OperatorUtils.managedServicesRequest(client).withName(MANAGED_KAFKA_REQUEST_NAME).get())
                 .map(r -> {
 
                     LOGGER.info("ManagedServicesRequest status is: {}", Json.encode(r.getStatus()));
@@ -222,13 +223,12 @@ public class BindingOperatorTest extends TestBase {
         assumeTrue(managedServicesRequest.getStatus() != null, "the ManagedServicesRequest status is null");
 
         var userKafka = managedServicesRequest.getStatus().getUserKafkas().stream()
-            .filter(k -> k.getName().equals(Environment.LONG_LIVED_KAFKA_NAME))
-            .findFirst();
+                .filter(k -> k.getName().equals(KAFKA_INSTANCE_NAME))
+                .findFirst();
 
         if (userKafka.isEmpty()) {
             LOGGER.info("ManagedServicesRequest: {}", Json.encode(managedServicesRequest));
-            fail(String.format("failed to find the user kafka instance %s in the ManagedServicesRequest %s",
-                Environment.LONG_LIVED_KAFKA_NAME, MANAGED_KAFKA_REQUEST_NAME));
+            fail(String.format("failed to find the user kafka instance %s in the ManagedServicesRequest %s", KAFKA_INSTANCE_NAME, MANAGED_KAFKA_REQUEST_NAME));
         }
 
         var c = new ManagedKafkaConnection();
@@ -242,8 +242,7 @@ public class BindingOperatorTest extends TestBase {
         c = OperatorUtils.managedKafkaConnection(client).create(c);
         LOGGER.info("created ManagedKafkaConnection: {}", Json.encode(c));
 
-        IsReady<ManagedKafkaConnection> ready = last ->
-            Future.succeededFuture(OperatorUtils.managedKafkaConnection(client).withName(MANAGED_KAFKA_CONNECTION_NAME).get())
+        IsReady<ManagedKafkaConnection> ready = last -> Future.succeededFuture(OperatorUtils.managedKafkaConnection(client).withName(MANAGED_KAFKA_CONNECTION_NAME).get())
                 .map(r -> {
 
                     LOGGER.info("ManagedKafkaConnection status is: {}", Json.encode(r.getStatus()));

--- a/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
@@ -3,6 +3,7 @@ package io.managed.services.test;
 import io.managed.services.test.client.kafka.KafkaAdmin;
 import io.managed.services.test.client.kafka.KafkaConsumerClient;
 import io.managed.services.test.client.kafka.KafkaProducerClient;
+import io.managed.services.test.client.serviceapi.CreateKafkaPayload;
 import io.managed.services.test.client.serviceapi.CreateServiceAccountPayload;
 import io.managed.services.test.client.serviceapi.KafkaResponse;
 import io.managed.services.test.client.serviceapi.ServiceAPI;
@@ -14,11 +15,8 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -28,16 +26,15 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.managed.services.test.TestUtils.await;
-import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.deleteServiceAccountByNameIfExists;
+import static io.managed.services.test.client.kafka.KafkaUtils.getTopicByName;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getKafkaByName;
+import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getServiceAccountByName;
+import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.waitUntilKafkaIsReady;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -49,20 +46,19 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class ServiceAPILongLiveTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPITest.class);
 
+    static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
     static final String SERVICE_ACCOUNT_NAME = "mk-e2e-ll-sa-" + Environment.KAFKA_POSTFIX_NAME;
+    static final String TOPIC_NAME = "ll-test-topic";
 
     ServiceAPI api;
 
     KafkaResponse kafka;
+    ServiceAccount serviceAccount;
+    String topic;
 
     @BeforeAll
     void bootstrap(Vertx vertx) {
         api = await(ServiceAPIUtils.serviceAPI(vertx));
-    }
-
-    @AfterAll
-    void deleteServiceAccount() {
-        await(deleteServiceAccountByNameIfExists(api, SERVICE_ACCOUNT_NAME));
     }
 
     void assertAPI() {
@@ -73,57 +69,109 @@ class ServiceAPILongLiveTest extends TestBase {
         assumeTrue(kafka != null, "kafka is null because the testPresenceOfLongLiveKafkaInstance has failed to create the Kafka instance");
     }
 
+    void assertServiceAccount() {
+        assumeTrue(serviceAccount != null, "serviceAccount is null because the testPresenceOfTheServiceAccount has failed to create the Service Account");
+    }
+
+    void assertTopic() {
+        assumeTrue(topic != null, "topic is null because the testPresenceOfTopic has failed to create the Topic");
+    }
+
     @Test
     @Timeout(value = 15, timeUnit = TimeUnit.MINUTES)
     @Order(1)
-    void testPresenceOfLongLiveKafkaInstance() {
+    void testPresenceOfLongLiveKafkaInstance(Vertx vertx) {
         assertAPI();
 
-        LOGGER.info("Get kafka instance for name: {}", Environment.LONG_LIVED_KAFKA_NAME);
-        Optional<KafkaResponse> optionalKafka = await(getKafkaByName(api, Environment.LONG_LIVED_KAFKA_NAME));
+        LOGGER.info("get kafka instance for name: {}", KAFKA_INSTANCE_NAME);
+        var optionalKafka = await(getKafkaByName(api, KAFKA_INSTANCE_NAME));
         if (optionalKafka.isEmpty()) {
-            LOGGER.error("kafka is not present :{} ", Environment.LONG_LIVED_KAFKA_NAME);
-            fail(String.format("Something went wrong, kafka is missing. Please create a kafka with name: %s if not created before!", Environment.LONG_LIVED_KAFKA_NAME));
+            LOGGER.error("kafka is not present: {}", KAFKA_INSTANCE_NAME);
+
+            LOGGER.info("try to recreate the kafka instance: {}", KAFKA_INSTANCE_NAME);
+            // Create Kafka Instance
+            var kafkaPayload = new CreateKafkaPayload();
+            kafkaPayload.name = KAFKA_INSTANCE_NAME;
+            kafkaPayload.multiAZ = true;
+            kafkaPayload.cloudProvider = "aws";
+            kafkaPayload.region = "us-east-1";
+
+            LOGGER.info("create kafka instance: {}", kafkaPayload.name);
+            var k = await(api.createKafka(kafkaPayload, true));
+            kafka = await(waitUntilKafkaIsReady(vertx, api, k.id));
+
+            fail(String.format("for some reason the long living kafka instance with name: %s didn't exists anymore but we have recreate it", KAFKA_INSTANCE_NAME));
         }
 
         kafka = optionalKafka.get();
-        LOGGER.info("kafka is present :{} and created at: {}", Environment.LONG_LIVED_KAFKA_NAME, kafka.createdAt);
+        LOGGER.info("kafka is present :{} and created at: {}", KAFKA_INSTANCE_NAME, kafka.createdAt);
     }
 
     @Test
     @Order(2)
-    void testProduceAndConsumeKafkaMessages(Vertx vertx) {
+    void testPresenceOfServiceAccount() {
         assertKafka();
 
-        // Create Service Account
-        CreateServiceAccountPayload serviceAccountPayload = new CreateServiceAccountPayload();
-        serviceAccountPayload.name = SERVICE_ACCOUNT_NAME;
+        LOGGER.info("get service account by name: {}", SERVICE_ACCOUNT_NAME);
+        var optionalAccount = await(getServiceAccountByName(api, SERVICE_ACCOUNT_NAME));
+        if (optionalAccount.isEmpty()) {
+            LOGGER.error("service account is not present: {}", SERVICE_ACCOUNT_NAME);
 
-        LOGGER.info("create service account: {}", serviceAccountPayload.name);
-        ServiceAccount serviceAccount = await(api.createServiceAccount(serviceAccountPayload));
+            LOGGER.info("try to recreate the service account: {}", SERVICE_ACCOUNT_NAME);
+            // Create Service Account
+            var serviceAccountPayload = new CreateServiceAccountPayload();
+            serviceAccountPayload.name = SERVICE_ACCOUNT_NAME;
+
+            LOGGER.info("create service account: {}", serviceAccountPayload.name);
+            serviceAccount = await(api.createServiceAccount(serviceAccountPayload));
+
+            fail(String.format("for some reason the long living service account with name: %s didn't exists anymore but we have recreate it", SERVICE_ACCOUNT_NAME));
+        }
+
+        LOGGER.info("reset credentials for service account: {}", SERVICE_ACCOUNT_NAME);
+        serviceAccount = await(api.resetCredentialsServiceAccount(optionalAccount.get().id));
+    }
+
+    @Test
+    @Order(3)
+    void testPresenceOfTopic() {
+        assertServiceAccount();
 
         String bootstrapHost = kafka.bootstrapServerHost;
         String clientID = serviceAccount.clientID;
         String clientSecret = serviceAccount.clientSecret;
 
         LOGGER.info("initialize kafka admin; host: {}; clientID: {}; clientSecret: {}", bootstrapHost, clientID, clientSecret);
-        KafkaAdmin admin = new KafkaAdmin(bootstrapHost, clientID, clientSecret);
+        var admin = new KafkaAdmin(bootstrapHost, clientID, clientSecret);
 
-        String topicName = Environment.LONG_LIVED_KAFKA_TOPIC_NAME;
-        LOGGER.info("Get kafka topic by name: {}", topicName);
+        LOGGER.info("get the topic by name: {}", TOPIC_NAME);
+        var optionalTopic = await(getTopicByName(admin, TOPIC_NAME));
 
-        try {
-            Map<String, TopicDescription> result = await(admin.getMapOfTopicNameAndDescriptionByName(topicName));
-            if (result.containsKey(topicName)) {
-                LOGGER.info("Topic is already available for the long live instance");
-            }
-        } catch (CompletionException exception) {
-            if (exception.getCause() instanceof UnknownTopicOrPartitionException) {
-                LOGGER.error("topic is not present: {} in instance: {} ", Environment.LONG_LIVED_KAFKA_TOPIC_NAME, Environment.LONG_LIVED_KAFKA_NAME);
-                LOGGER.error("please create the topic with name '{}' in the '{}' instance", Environment.LONG_LIVED_KAFKA_TOPIC_NAME, Environment.LONG_LIVED_KAFKA_NAME);
-            }
-            fail(exception);
+        if (optionalTopic.isEmpty()) {
+            LOGGER.error("topic is not present: {}", TOPIC_NAME);
+
+            LOGGER.info("try to recreate the topic: {}", TOPIC_NAME);
+            await(admin.createTopic(TOPIC_NAME));
+
+            topic = TOPIC_NAME;
+
+            fail(String.format("for some reason the long living topic: %s in the kafka instance: %s didn't exists anymore but we have recreate it",
+                    KAFKA_INSTANCE_NAME, TOPIC_NAME));
         }
+
+        LOGGER.info("topic is present :{}", TOPIC_NAME);
+        topic = TOPIC_NAME;
+    }
+
+    @Test
+    @Order(4)
+    void testProduceAndConsumeKafkaMessages(Vertx vertx) {
+        assertTopic();
+
+        String bootstrapHost = kafka.bootstrapServerHost;
+        String clientID = serviceAccount.clientID;
+        String clientSecret = serviceAccount.clientSecret;
+        String topicName = topic;
 
         int msgCount = 1000;
         List<String> messages = IntStream.range(0, msgCount).boxed().map(i -> "hello-world-" + i).collect(Collectors.toList());


### PR DESCRIPTION
* add service account reset-credentials
* split long-living instance tests
* add recreate logic for service account, topics, and kafka instance