### PR TITLE
Set Vertx and VertxTestContext parameters to null

### DIFF
--- a/src/main/java/io/managed/services/test/framework/CustomReportPortalExtension.java
+++ b/src/main/java/io/managed/services/test/framework/CustomReportPortalExtension.java
@@ -1,0 +1,34 @@
+package io.managed.services.test.framework;
+
+import com.epam.reportportal.junit5.ItemType;
+import com.epam.reportportal.junit5.ReportPortalExtension;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.annotation.Nonnull;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CustomReportPortalExtension extends ReportPortalExtension {
+    private static final Logger LOGGER = LogManager.getLogger(CustomReportPortalExtension.class);
+
+    @Override
+    protected void startTestItem(@Nonnull final ExtensionContext context, @Nonnull final List<Object> arguments,
+                                 @Nonnull final ItemType itemType, @Nonnull final String description, @Nonnull final Date startTime) {
+
+        var cleanedArguments = arguments.stream().map(a -> {
+            // remove the Vertx and VertxTestContext from the parameters otherwise ReportPortal will not
+            // display the test history because it will think that is a different test
+            if (a instanceof Vertx || a instanceof VertxTestContext) {
+                return null;
+            }
+            return a;
+        }).collect(Collectors.toList());
+
+        super.startTestItem(context, cleanedArguments, itemType, description, startTime);
+    }
+}

--- a/src/test/java/io/managed/services/test/TestBase.java
+++ b/src/test/java/io/managed/services/test/TestBase.java
@@ -1,6 +1,5 @@
 package io.managed.services.test;
 
-import com.epam.reportportal.junit5.ReportPortalExtension;
 import io.managed.services.test.framework.ExtensionContextParameterResolver;
 import io.managed.services.test.framework.IndicativeSentences;
 import io.managed.services.test.framework.TestCallbackListener;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(TestCallbackListener.class)
 @ExtendWith(TestExceptionCallbackListener.class)
 @ExtendWith(ExtensionContextParameterResolver.class)
-@ExtendWith(ReportPortalExtension.class)
 @DisplayNameGeneration(IndicativeSentences.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TestBase {

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,1 @@
-com.epam.reportportal.junit5.ReportPortalExtension
+io.managed.services.test.framework.CustomReportPortalExtension


### PR DESCRIPTION
**Why**

The Vertx and VertxTestContext parameters are reported to report portal using the object ID as value and therefore RP things that is a new test every time 

![image](https://user-images.githubusercontent.com/7964685/110791211-3d399a80-8272-11eb-8d4b-f45bca143cf3.png)
