### PR TITLE
Add timeout to testTopic method to close the producer and consumer in time

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafka/KafkaProducerClient.java
+++ b/src/main/java/io/managed/services/test/client/kafka/KafkaProducerClient.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 public class KafkaProducerClient {
     private static final Logger LOGGER = LogManager.getLogger(KafkaProducerClient.class);
     private final Vertx vertx;
@@ -57,8 +55,8 @@ public class KafkaProducerClient {
     public Future<Void> close() {
         if (vertx != null && producer != null) {
             return producer.close()
-                    .onSuccess(v -> LOGGER.info("Producer closed"))
-                    .onFailure(cause -> fail("Producer not closed", cause));
+                    .onSuccess(v -> LOGGER.info("KafkaProducerClient closed"))
+                    .onFailure(c -> LOGGER.error("failed to close KafkaProducerClient", c));
         }
         return Future.succeededFuture(null);
     }

--- a/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
@@ -33,6 +33,7 @@ import static io.managed.services.test.client.kafka.KafkaUtils.applyTopics;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getKafkaByName;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getServiceAccountByName;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.waitUntilKafkaIsReady;
+import static java.time.Duration.ofMinutes;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -175,10 +176,9 @@ class ServiceAPILongLiveTest extends TestBase {
         String clientID = serviceAccount.clientID;
         String clientSecret = serviceAccount.clientSecret;
 
-
         forEach(Set.of(TOPICS), topic -> {
             LOGGER.info("start testing topic: {}", topic);
-            return testTopic(vertx, bootstrapHost, clientID, clientSecret, topic, 10, 7, 10);
+            return testTopic(vertx, bootstrapHost, clientID, clientSecret, topic, ofMinutes(1), 10, 7, 10);
         }).onComplete(context.succeedingThenComplete());
     }
 }

--- a/src/test/java/io/managed/services/test/ServiceAPISameOrgUserPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPISameOrgUserPermissionsTest.java
@@ -128,7 +128,7 @@ public class ServiceAPISameOrgUserPermissionsTest extends TestBase {
 
     @Test
     @Order(2)
-    @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
+    @Timeout(value = 3, timeUnit = TimeUnit.MINUTES)
     void testUser2ProduceAndConsumeKafkaMessages(Vertx vertx, VertxTestContext context) {
         assertKafka();
 

--- a/src/test/java/io/managed/services/test/ServiceAPITest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPITest.java
@@ -157,7 +157,7 @@ class ServiceAPITest extends TestBase {
 
     @Test
     @Order(3)
-    @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
+    @Timeout(value = 3, timeUnit = TimeUnit.MINUTES)
     void testProduceAndConsumeKafkaMessages(Vertx vertx, VertxTestContext context) {
         assertTopic();
 

--- a/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
@@ -71,7 +71,7 @@ public class ServiceAPIUserMetricsTest extends TestBase {
 
     @Test
     @Order(1)
-    @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
+    @Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
     void testMessageInTotalMetric(Vertx vertx, VertxTestContext context) {
         assertAPI();
 


### PR DESCRIPTION
I start to saw errors like this on the test runs:
```
14:17:06 2021-03-12 13:17:06 ERROR [415] [NetworkClient:746] [AdminClient clientId=adminclient-3] Connection to node 0 (broker-0-mk-e-e-ci--pes-tk-xikt-iw-mvwu-wicfnw.kafka.devshift.org/52.21.54.237:443) failed authentication due to: SSL handshake failed
14:17:06 2021-03-12 13:17:06 WARN  [415] [AdminMetadataManager:232] [AdminClient clientId=adminclient-3] Metadata update failed due to authentication error
14:17:06 org.apache.kafka.common.errors.SslAuthenticationException: SSL handshake failed
14:17:06 Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
14:17:06 	at sun.security.ssl.Alert.createSSLException(Alert.java:131) ~[?:?]
14:17:06 	at sun.security.ssl.TransportContext.fatal(TransportContext.java:349) ~[?:?]
14:17:06 	at sun.security.ssl.TransportContext.fatal(TransportContext.java:292) ~[?:?]
14:17:06 	at sun.security.ssl.TransportContext.fatal(TransportContext.java:287) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1356) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1231) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1174) ~[?:?]
14:17:06 	at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392) ~[?:?]
14:17:06 	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:443) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1074) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1061) ~[?:?]
14:17:06 	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1008) ~[?:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.runDelegatedTasks(SslTransportLayer.java:430) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshakeUnwrap(SslTransportLayer.java:514) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.doHandshake(SslTransportLayer.java:368) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshake(SslTransportLayer.java:291) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.KafkaChannel.prepare(KafkaChannel.java:173) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:547) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.poll(Selector.java:485) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:544) [kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests(KafkaAdminClient.java:1293) [kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run(KafkaAdminClient.java:1224) [kafka-clients-2.6.0.jar:?]
14:17:06 	at java.lang.Thread.run(Thread.java:834) [?:?]
14:17:06 Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
14:17:06 	at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:439) ~[?:?]
14:17:06 	at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:306) ~[?:?]
14:17:06 	at sun.security.validator.Validator.validate(Validator.java:264) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:313) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:276) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:141) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1334) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1231) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1174) ~[?:?]
14:17:06 	at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392) ~[?:?]
14:17:06 	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:443) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1074) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1061) ~[?:?]
14:17:06 	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1008) ~[?:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.runDelegatedTasks(SslTransportLayer.java:430) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshakeUnwrap(SslTransportLayer.java:514) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.doHandshake(SslTransportLayer.java:368) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshake(SslTransportLayer.java:291) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.KafkaChannel.prepare(KafkaChannel.java:173) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:547) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.poll(Selector.java:485) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:544) [kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests(KafkaAdminClient.java:1293) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run(KafkaAdminClient.java:1224) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at java.lang.Thread.run(Thread.java:834) ~[?:?]
14:17:06 Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
14:17:06 	at sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:141) ~[?:?]
14:17:06 	at sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:126) ~[?:?]
14:17:06 	at java.security.cert.CertPathBuilder.build(CertPathBuilder.java:297) ~[?:?]
14:17:06 	at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:434) ~[?:?]
14:17:06 	at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:306) ~[?:?]
14:17:06 	at sun.security.validator.Validator.validate(Validator.java:264) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:313) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:276) ~[?:?]
14:17:06 	at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:141) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1334) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1231) ~[?:?]
14:17:06 	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1174) ~[?:?]
14:17:06 	at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392) ~[?:?]
14:17:06 	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:443) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1074) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1061) ~[?:?]
14:17:06 	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
14:17:06 	at sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1008) ~[?:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.runDelegatedTasks(SslTransportLayer.java:430) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshakeUnwrap(SslTransportLayer.java:514) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.doHandshake(SslTransportLayer.java:368) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.SslTransportLayer.handshake(SslTransportLayer.java:291) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.KafkaChannel.prepare(KafkaChannel.java:173) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:547) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.common.network.Selector.poll(Selector.java:485) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:544) [kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests(KafkaAdminClient.java:1293) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run(KafkaAdminClient.java:1224) ~[kafka-clients-2.6.0.jar:?]
14:17:06 	at java.lang.Thread.run(Thread.java:834) ~[?:?]
14:17:06 2021-03-12 13:17:06 INFO  [386] [AdminMetadataManager:235] [AdminClient clientId=adminclient-2] Metadata update failed
14:17:06 org.apache.kafka.common.errors.TimeoutException: Call(callName=fetchMetadata, deadlineMs=1615555026087, tries=1, nextAllowedTryMs=1615555026188) timed out at 1615555026088 after 1 attempt(s)
14:17:06 Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment.
14:17:06 2021-03-12 13:17:06 INFO  [415] [Selector:620] [AdminClient clientId=adminclient-3] Failed authentication with broker-1-mk-e-e-ci--pes-tk-xikt-iw-mvwu-wicfnw.kafka.devshift.org/3.217.73.47 (SSL handshake failed)
```
because one of the tests went in timeout and it failed to close the consumer.