### PR TITLE
Add Timeout annotation to each class

### DIFF
--- a/src/test/java/io/managed/services/test/BindingOperatorTest.java
+++ b/src/test/java/io/managed/services/test/BindingOperatorTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.BINDING_OPERATOR)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class BindingOperatorTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(BindingOperatorTest.class);

--- a/src/test/java/io/managed/services/test/CLITest.java
+++ b/src/test/java/io/managed/services/test/CLITest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.CLI)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CLITest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(CLITest.class);
@@ -176,9 +177,7 @@ public class CLITest extends TestBase {
                     return cli.listKafka(vertx);
                 })
 
-                .onSuccess(__ -> {
-                    loggedIn = true;
-                })
+                .onSuccess(__ -> loggedIn = true)
 
                 .onComplete(context.succeedingThenComplete());
     }

--- a/src/test/java/io/managed/services/test/ServiceAPIDiffOrgUserPermissionTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIDiffOrgUserPermissionTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.SERVICE_API_PERMISSIONS)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ServiceAPIDiffOrgUserPermissionTest extends TestBase {
 

--- a/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.SERVICE_API)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ServiceAPILongLiveTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPITest.class);

--- a/src/test/java/io/managed/services/test/ServiceAPISameOrgUserPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPISameOrgUserPermissionsTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.SERVICE_API_PERMISSIONS)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ServiceAPISameOrgUserPermissionsTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPISameOrgUserPermissionsTest.class);

--- a/src/test/java/io/managed/services/test/ServiceAPITest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPITest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.SERVICE_API)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ServiceAPITest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPITest.class);

--- a/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
@@ -7,6 +7,7 @@ import io.managed.services.test.client.serviceapi.ServiceAPIUtils;
 import io.managed.services.test.framework.TestTag;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -23,6 +24,7 @@ import org.opentest4j.TestAbortedException;
 
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static io.managed.services.test.TestUtils.message;
 import static io.managed.services.test.TestUtils.waitFor;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(TestTag.SERVICE_API)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ServiceAPIUserMetricsTest extends TestBase {
 

--- a/src/test/java/io/managed/services/test/ServiceAPUnauthorizedAndUnauthenticatedUserTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPUnauthorizedAndUnauthenticatedUserTest.java
@@ -6,6 +6,7 @@ import io.managed.services.test.client.serviceapi.ServiceAPIUtils;
 import io.managed.services.test.framework.TestTag;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -17,9 +18,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 
 @Tag(TestTag.SERVICE_API_PERMISSIONS)
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ServiceAPUnauthorizedAndUnauthenticatedUserTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPISameOrgUserPermissionsTest.class);

--- a/src/test/java/io/managed/services/test/TestBase.java
+++ b/src/test/java/io/managed/services/test/TestBase.java
@@ -4,20 +4,16 @@ import io.managed.services.test.framework.ExtensionContextParameterResolver;
 import io.managed.services.test.framework.IndicativeSentences;
 import io.managed.services.test.framework.TestCallbackListener;
 import io.managed.services.test.framework.TestExceptionCallbackListener;
-import io.vertx.junit5.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.concurrent.TimeUnit;
-
 @ExtendWith(TestCallbackListener.class)
 @ExtendWith(TestExceptionCallbackListener.class)
 @ExtendWith(ExtensionContextParameterResolver.class)
 @DisplayNameGeneration(IndicativeSentences.class)
-@Timeout(value = 5, timeUnit = TimeUnit.MINUTES)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TestBase {
     private static final Logger LOGGER = LogManager.getLogger(TestBase.class);


### PR DESCRIPTION
**Why**
vertx Timeout annotation is not inheritable from the extended class