### PR TITLE
Use long living service account for metrics tests to reduce the number of SA created

### DIFF
--- a/src/test/java/io/managed/services/test/BindingOperatorTest.java
+++ b/src/test/java/io/managed/services/test/BindingOperatorTest.java
@@ -60,7 +60,7 @@ public class BindingOperatorTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(BindingOperatorTest.class);
 
     // use the kafka long living instance
-    static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
+    static final String KAFKA_INSTANCE_NAME = ServiceAPILongLiveTest.KAFKA_INSTANCE_NAME;
 
     User user;
     ServiceAPI api;

--- a/src/test/java/io/managed/services/test/QuarkusSampleTest.java
+++ b/src/test/java/io/managed/services/test/QuarkusSampleTest.java
@@ -44,7 +44,7 @@ public class QuarkusSampleTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(QuarkusSampleTest.class);
 
     // use the kafka long living instance
-    static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
+    static final String KAFKA_INSTANCE_NAME = ServiceAPILongLiveTest.KAFKA_INSTANCE_NAME;
 
     // this name is decided from the cli
     static final String ACCESS_TOKEN_SECRET_NAME = "rh-cloud-services-accesstoken-cli";

--- a/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
@@ -45,8 +45,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class ServiceAPILongLiveTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(ServiceAPILongLiveTest.class);
 
-    private static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
-    private static final String SERVICE_ACCOUNT_NAME = "mk-e2e-ll-sa-" + Environment.KAFKA_POSTFIX_NAME;
+    public static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
+    public static final String SERVICE_ACCOUNT_NAME = "mk-e2e-ll-sa-" + Environment.KAFKA_POSTFIX_NAME;
     private static final String[] TOPICS = {"ll-topic-az", "ll-topic-cb", "ll-topic-fc", "ll-topic-bf", "ll-topic-cd"};
 
     ServiceAPI api;

--- a/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIUserMetricsTest.java
@@ -51,8 +51,8 @@ public class ServiceAPIUserMetricsTest extends TestBase {
     private static final Duration WAIT_FOR_METRIC_TIMEOUT = Duration.ofMinutes(2);
 
     // use the kafka long living instance
-    private static final String KAFKA_INSTANCE_NAME = "mk-e2e-ll-" + Environment.KAFKA_POSTFIX_NAME;
-    private static final String SERVICE_ACCOUNT_NAME = "mk-e2e-metrics-sa-" + Environment.KAFKA_POSTFIX_NAME;
+    private static final String KAFKA_INSTANCE_NAME = ServiceAPILongLiveTest.KAFKA_INSTANCE_NAME;
+    private static final String SERVICE_ACCOUNT_NAME = ServiceAPILongLiveTest.SERVICE_ACCOUNT_NAME;
 
     // use a special topic
     private static final String TOPIC_NAME = "metric-test-topic";


### PR DESCRIPTION
**Why**
We are limited to 2 service account from now on