### PR TITLE
duplicate test messageMetric for long live instance and newly created…

### DIFF
--- a/src/main/java/io/managed/services/test/client/serviceapi/MetricsUtils.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/MetricsUtils.java
@@ -1,9 +1,34 @@
 package io.managed.services.test.client.serviceapi;
 
+import io.managed.services.test.IsReady;
+import io.managed.services.test.client.kafkaadminapi.KafkaAdminAPIUtils;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.javatuples.Pair;
+import org.opentest4j.TestAbortedException;
+
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
+
+import static io.managed.services.test.TestUtils.message;
+import static io.managed.services.test.TestUtils.waitFor;
+import static io.managed.services.test.client.kafka.KafkaMessagingUtils.testTopicWithOauth;
+import static io.managed.services.test.client.kafkaadminapi.KafkaAdminAPIUtils.applyTopics;
+import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.applyServiceAccount;
+import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getKafkaByName;
+import static java.time.Duration.ofSeconds;
 
 public class MetricsUtils {
-
+    private static final Logger LOGGER = LogManager.getLogger(MetricsUtils.class);
+    private static final String TOPIC_NAME = "metric-test-topic";
+    private static final String IN_MESSAGES_METRIC = "kafka_server_brokertopicmetrics_messages_in_total";
+    private static final int MESSAGE_COUNT = 17;
+    private static final Duration WAIT_FOR_METRIC_TIMEOUT = Duration.ofMinutes(2);
     /**
      * Return the sum for all values of a single metric and topic
      *
@@ -20,4 +45,74 @@ public class MetricsUtils {
                 .filter(item -> item.metric.topic.equals(topicName))
                 .reduce((double) 0, (__, item) -> item.value, (a, b) -> a + b);
     }
+
+    public static Future messageInTotalMetric(ServiceAPI api, String  kafkaInstanceName, String serviceAccountName, Vertx vertx) {
+        LOGGER.info("start testing message in total metric");
+        Promise promise = Promise.promise();
+        // retrieve the kafka info
+        var kafkaF = getKafkaByName(api, kafkaInstanceName)
+                .map(o -> o.orElseThrow(() -> new TestAbortedException(message("can't find the long living kafka instance: {}", kafkaInstanceName))));
+
+
+        var serviceAccountF = applyServiceAccount(api, serviceAccountName);
+
+        var adminF = CompositeFuture.all(kafkaF, serviceAccountF)
+                .compose(__ -> {
+                    var bootstrapHost = kafkaF.result().bootstrapServerHost;
+                    return KafkaAdminAPIUtils.kafkaAdminAPI(vertx, bootstrapHost);
+                });
+
+        // ensure the topic exists
+        var topicF = adminF
+                .compose(__ -> {
+                    LOGGER.info("ensure the topic {} exists", TOPIC_NAME);
+                    return applyTopics(adminF.result(), Set.of(TOPIC_NAME));
+                });
+
+        // retrieve the current in messages before sending more
+        var initialInMessagesF = topicF
+                .compose(__ -> api.queryMetrics(kafkaF.result().id))
+                .map(r -> collectTopicMetric(r.items, TOPIC_NAME, IN_MESSAGES_METRIC))
+                .onSuccess(i -> LOGGER.info("the topic '{}' started with '{}' in messages", TOPIC_NAME, i));
+
+        // send n messages to the topic
+        var testTopicF = initialInMessagesF
+                .compose(__ -> {
+                    String bootstrapHost = kafkaF.result().bootstrapServerHost;
+                    String clientID = serviceAccountF.result().clientID;
+                    String clientSecret = serviceAccountF.result().clientSecret;
+
+                    LOGGER.info("send {} message to the topic: {}", MESSAGE_COUNT, TOPIC_NAME);
+                    return testTopicWithOauth(vertx, bootstrapHost, clientID, clientSecret, TOPIC_NAME, MESSAGE_COUNT, 10, 100);
+                });
+
+        // wait for the metric to be updated or fail with timeout
+        IsReady<Double> isMetricUpdated = last -> api.queryMetrics(kafkaF.result().id)
+                .map(r -> {
+                    var in = collectTopicMetric(r.items, TOPIC_NAME, IN_MESSAGES_METRIC);
+                    if (last) {
+                        LOGGER.warn("last kafka_server_brokertopicmetrics_messages_in_total value: {}", in);
+                    }
+
+                    var initialInMessage = initialInMessagesF.result();
+                    return Pair.with(initialInMessage + MESSAGE_COUNT == in, in);
+                });
+        var inMessagesF = testTopicF
+                .compose(__ -> waitFor(vertx, "metric to be updated", ofSeconds(3), WAIT_FOR_METRIC_TIMEOUT, isMetricUpdated));
+
+        inMessagesF
+                .onSuccess(i -> LOGGER.info("final in message count for topic '{}' is: {}", TOPIC_NAME, i))
+                .onSuccess(i -> {
+                    if (i != initialInMessagesF.result() + MESSAGE_COUNT) promise.fail(new Exception("count of messages in 2 sources doesn't match"));
+                    else {
+                        promise.complete();
+                    }
+                })
+                .onFailure(i -> promise.fail("intern error"));
+
+        return promise.future();
+    }
 }
+
+
+

--- a/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPILongLiveTest.java
@@ -32,6 +32,7 @@ import static io.managed.services.test.TestUtils.forEach;
 import static io.managed.services.test.TestUtils.message;
 import static io.managed.services.test.client.kafka.KafkaMessagingUtils.testTopic;
 import static io.managed.services.test.client.kafkaadminapi.KafkaAdminAPIUtils.applyTopics;
+import static io.managed.services.test.client.serviceapi.MetricsUtils.messageInTotalMetric;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getKafkaByName;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getServiceAccountByName;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.waitUntilKafkaIsReady;
@@ -214,6 +215,15 @@ class ServiceAPILongLiveTest extends TestBase {
             LOGGER.info("start testing topic: {}", topic);
             return testTopic(vertx, bootstrapHost, clientID, clientSecret, topic, ofMinutes(1), 10, 7, 10, true);
         }).onComplete(context.succeedingThenComplete());
+    }
+
+    @Test
+    @Order(5)
+    void testMessageInTotalMetric(Vertx vertx, VertxTestContext context) {
+        assertAPI();
+        LOGGER.info("start testing message in total metric");
+        messageInTotalMetric(api, KAFKA_INSTANCE_NAME, SERVICE_ACCOUNT_NAME, vertx)
+                .onComplete(context.succeedingThenComplete());
     }
 }
 

--- a/src/test/java/io/managed/services/test/ServiceAPITest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPITest.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import static io.managed.services.test.TestUtils.sleep;
 import static io.managed.services.test.client.kafka.KafkaMessagingUtils.testTopicPlain;
 import static io.managed.services.test.client.kafka.KafkaMessagingUtils.testTopicWithOauth;
+import static io.managed.services.test.client.serviceapi.MetricsUtils.messageInTotalMetric;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.deleteKafkaByNameIfExists;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.deleteServiceAccountByNameIfExists;
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getKafkaByName;
@@ -165,6 +166,15 @@ class ServiceAPITest extends TestBase {
                 .compose(api -> KafkaAdminAPIUtils.createDefaultTopic(api, TOPIC_NAME))
                 .onSuccess(__ -> topic = TOPIC_NAME)
 
+                .onComplete(context.succeedingThenComplete());
+    }
+
+    @Test
+    @Order(2)
+    void testMessageInTotalMetric(Vertx vertx, VertxTestContext context) {
+        assertAPI();
+        LOGGER.info("start testing message in total metric");
+        messageInTotalMetric(api, KAFKA_INSTANCE_NAME, SERVICE_ACCOUNT_NAME, vertx)
                 .onComplete(context.succeedingThenComplete());
     }
 


### PR DESCRIPTION
duplication of testing message metrics for both newly created, and long existing kafka cluster instance. 
 removal of ServiceAPIUserMetricsTest class, due to it's redundancy after this change.