### PR TITLE
Close vert.x in the class teardown

### DIFF
--- a/src/test/java/io/managed/services/test/KafkaAPILimitTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPILimitTest.java
@@ -44,7 +44,14 @@ public class KafkaAPILimitTest extends TestBase {
 
     @AfterClass
     public void teardown() throws Throwable {
-        bwait(cleanServiceAccounts());
+        try {
+            bwait(cleanServiceAccounts());
+        } catch (Throwable t) {
+            LOGGER.info("clean service account error: ", t);
+        }
+
+        // close vertx
+        bwait(vertx.close());
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT, enabled = false)

--- a/src/test/java/io/managed/services/test/KafkaAPITest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPITest.java
@@ -70,7 +70,7 @@ public class KafkaAPITest extends TestBase {
     }
 
     @AfterClass
-    public void teardown() {
+    public void teardown() throws Throwable {
 
         // delete kafka instance
         try {
@@ -91,6 +91,9 @@ public class KafkaAPITest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("clean service account error: ", t);
         }
+
+        // close vertx
+        bwait(vertx.close());
     }
 
     @Test(timeOut = 15 * MINUTES)

--- a/src/test/java/io/managed/services/test/KafkaAPIUserPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPIUserPermissionsTest.java
@@ -56,7 +56,7 @@ public class KafkaAPIUserPermissionsTest extends TestBase {
     }
 
     @AfterClass(timeOut = DEFAULT_TIMEOUT)
-    public void teardown() {
+    public void teardown() throws Throwable {
         assumeTeardown();
 
         try {
@@ -76,6 +76,8 @@ public class KafkaAPIUserPermissionsTest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("clean alien service account error: ", t);
         }
+
+        bwait(vertx.close());
     }
 
     @Test(timeOut = 15 * MINUTES)
@@ -191,6 +193,8 @@ public class KafkaAPIUserPermissionsTest extends TestBase {
 
         LOGGER.info("create kafka topic: {}", topicName);
         assertThrows(SaslAuthenticationException.class, () -> bwait(admin.createTopic(topicName)));
+
+        admin.close();
     }
 
     @Test(dependsOnMethods = "testMainUserCreateKafkaInstance", priority = 1, timeOut = DEFAULT_TIMEOUT)

--- a/src/test/java/io/managed/services/test/KafkaAdminAPITest.java
+++ b/src/test/java/io/managed/services/test/KafkaAdminAPITest.java
@@ -65,7 +65,7 @@ public class KafkaAdminAPITest extends TestBase {
     }
 
     @AfterClass(timeOut = DEFAULT_TIMEOUT)
-    public void teardown() {
+    public void teardown() throws Throwable {
         assumeTeardown();
 
         // delete kafka instance
@@ -81,6 +81,9 @@ public class KafkaAdminAPITest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("failed to clean service account: ", t);
         }
+
+        // close vertx
+        bwait(vertx.close());
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT)

--- a/src/test/java/io/managed/services/test/KafkaAdminPermissionTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAdminPermissionTest.java
@@ -48,7 +48,7 @@ public class KafkaAdminPermissionTest extends TestBase {
     private KafkaConsumer<String, String> consumer;
 
     @AfterClass(timeOut = DEFAULT_TIMEOUT)
-    public void teardown() {
+    public void teardown() throws Throwable {
         // close KafkaAdmin
         if (admin != null) admin.close();
 
@@ -76,11 +76,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         }
 
         // close vertx
-        try {
-            vertx.close();
-        } catch (Throwable t) {
-            LOGGER.error("failed to close vertx: ", t);
-        }
+        bwait(vertx.close());
     }
 
     @BeforeClass(timeOut = 15 * MINUTES)

--- a/src/test/java/io/managed/services/test/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/KafkaCLITest.java
@@ -97,6 +97,8 @@ public class KafkaCLITest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("cleanWorkdir error: ", t);
         }
+
+        bwait(vertx.close());
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT)

--- a/src/test/java/io/managed/services/test/KafkaOperatorTest.java
+++ b/src/test/java/io/managed/services/test/KafkaOperatorTest.java
@@ -166,7 +166,7 @@ public class KafkaOperatorTest extends TestBase {
     }
 
     @AfterClass(timeOut = DEFAULT_TIMEOUT)
-    public void teardown(ITestContext context) {
+    public void teardown(ITestContext context) throws Throwable {
         assumeTeardown();
 
         try {
@@ -205,6 +205,8 @@ public class KafkaOperatorTest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("cleanServiceAccount error: ", t);
         }
+
+        bwait(vertx.close());
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT)

--- a/src/test/java/io/managed/services/test/LongLiveKafkaTest.java
+++ b/src/test/java/io/managed/services/test/LongLiveKafkaTest.java
@@ -60,12 +60,14 @@ public class LongLiveKafkaTest extends TestBase {
     }
 
     @AfterClass
-    public void teardown() {
+    public void teardown() throws Throwable {
         try {
             bwait(kafkaAdminAPI.deleteTopic(MULTI_PARTITION_TOPIC_NAME));
         } catch (Throwable t) {
             LOGGER.error("failed to clean topic: {}", MULTI_PARTITION_TOPIC_NAME);
         }
+
+        bwait(vertx.close());
     }
 
     private void assertKafka() {

--- a/src/test/java/io/managed/services/test/QuarkusSampleTest.java
+++ b/src/test/java/io/managed/services/test/QuarkusSampleTest.java
@@ -300,7 +300,7 @@ public class QuarkusSampleTest extends TestBase {
     }
 
     @AfterClass(timeOut = 5 * MINUTES)
-    public void teardown(ITestContext context) {
+    public void teardown(ITestContext context) throws Throwable {
         assumeTeardown();
 
         try {
@@ -366,6 +366,8 @@ public class QuarkusSampleTest extends TestBase {
         } catch (Throwable e) {
             LOGGER.error("cleanCLI error: ", e);
         }
+
+        bwait(vertx.close());
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT)

--- a/src/test/java/io/managed/services/test/ServiceAPIUnauthUserTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIUnauthUserTest.java
@@ -8,6 +8,7 @@ import io.managed.services.test.framework.TestTag;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static io.managed.services.test.TestUtils.bwait;
@@ -51,6 +52,11 @@ public class ServiceAPIUnauthUserTest extends TestBase {
         "0KL0owSTYBWvFDkROI-ymDXfcRvEMVKyOdhljQNPZew4Ux4apBi9t-ncB9XabDo1" +
         "1eddbbmcV05FWDb8X4opshptnWDzAw4ZPhbjoTBhNEI2JbFssOSYpskNnkB4kKQb" +
         "BjVxAPldBNFwRKLOfvJNdY1jNurMY1xVMl2dbEpFBkqJf1lByU";
+
+    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    public void teardown() throws Throwable {
+        bwait(vertx.close());
+    }
 
     @Test(timeOut = DEFAULT_TIMEOUT)
     public void testUnauthorizedUser() throws Throwable {


### PR DESCRIPTION
To avoid leaving resource hanging between each test run we should close the vert.x object after each class