### PR TITLE
Run the teardown even if the bootstrap fails

### DIFF
--- a/src/test/java/io/managed/services/test/KafkaAPILimitTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPILimitTest.java
@@ -42,7 +42,7 @@ public class KafkaAPILimitTest extends TestBase {
         return ServiceAPIUtils.deleteServiceAccountsByOwnerIfExists(api, Environment.SSO_SECONDARY_USERNAME);
     }
 
-    @AfterClass
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         try {
             bwait(cleanServiceAccounts());

--- a/src/test/java/io/managed/services/test/KafkaAPITest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPITest.java
@@ -71,7 +71,7 @@ public class KafkaAPITest extends TestBase {
         return deleteServiceAccountByNameIfExists(api, SERVICE_ACCOUNT_NAME);
     }
 
-    @AfterClass
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
 
         // delete kafka instance

--- a/src/test/java/io/managed/services/test/KafkaAPIUserPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAPIUserPermissionsTest.java
@@ -55,7 +55,7 @@ public class KafkaAPIUserPermissionsTest extends TestBase {
         alienAPI = bwait(ServiceAPIUtils.serviceAPI(vertx, Environment.SSO_ALIEN_USERNAME, Environment.SSO_ALIEN_PASSWORD));
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         assumeTeardown();
 

--- a/src/test/java/io/managed/services/test/KafkaAdminAPITest.java
+++ b/src/test/java/io/managed/services/test/KafkaAdminAPITest.java
@@ -64,7 +64,7 @@ public class KafkaAdminAPITest extends TestBase {
         LOGGER.info("kafka instance created: {}", Json.encode(kafka));
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         assumeTeardown();
 

--- a/src/test/java/io/managed/services/test/KafkaAdminPermissionTest.java
+++ b/src/test/java/io/managed/services/test/KafkaAdminPermissionTest.java
@@ -47,7 +47,7 @@ public class KafkaAdminPermissionTest extends TestBase {
     private KafkaAdmin admin;
     private KafkaConsumer<String, String> consumer;
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         // close KafkaAdmin
         if (admin != null) admin.close();

--- a/src/test/java/io/managed/services/test/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/KafkaCLITest.java
@@ -69,7 +69,7 @@ public class KafkaCLITest extends TestBase {
         return Future.succeededFuture();
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void clean() throws Throwable {
 
         var api = bwait(ServiceAPIUtils.serviceAPI(vertx));

--- a/src/test/java/io/managed/services/test/KafkaOperatorTest.java
+++ b/src/test/java/io/managed/services/test/KafkaOperatorTest.java
@@ -165,7 +165,7 @@ public class KafkaOperatorTest extends TestBase {
         return deleteServiceAccountByNameIfExists(api, SERVICE_ACCOUNT_NAME);
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown(ITestContext context) throws Throwable {
         assumeTeardown();
 

--- a/src/test/java/io/managed/services/test/LongLiveKafkaTest.java
+++ b/src/test/java/io/managed/services/test/LongLiveKafkaTest.java
@@ -1,7 +1,8 @@
 package io.managed.services.test;
 
-import io.managed.services.test.client.kafka.KafkaConsumerClient;
+import io.managed.services.test.client.kafka.KafkaAdmin;
 import io.managed.services.test.client.kafka.KafkaAuthMethod;
+import io.managed.services.test.client.kafka.KafkaConsumerClient;
 import io.managed.services.test.client.kafkaadminapi.CreateTopicPayload;
 import io.managed.services.test.client.kafkaadminapi.KafkaAdminAPI;
 import io.managed.services.test.client.kafkaadminapi.KafkaAdminAPIUtils;
@@ -36,7 +37,6 @@ import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.getServ
 import static io.managed.services.test.client.serviceapi.ServiceAPIUtils.waitUntilKafkaIsReady;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import io.managed.services.test.client.kafka.KafkaAdmin;
 
 @Test(groups = TestTag.SERVICE_API)
 public class LongLiveKafkaTest extends TestBase {
@@ -64,7 +64,7 @@ public class LongLiveKafkaTest extends TestBase {
         api = bwait(ServiceAPIUtils.serviceAPI(vertx));
     }
 
-    @AfterClass
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         try {
             bwait(kafkaAdminAPI.deleteTopic(MULTI_PARTITION_TOPIC_NAME));

--- a/src/test/java/io/managed/services/test/QuarkusSampleTest.java
+++ b/src/test/java/io/managed/services/test/QuarkusSampleTest.java
@@ -300,7 +300,7 @@ public class QuarkusSampleTest extends TestBase {
         return Future.succeededFuture();
     }
 
-    @AfterClass(timeOut = 5 * MINUTES)
+    @AfterClass(timeOut = 5 * MINUTES, alwaysRun = true)
     public void teardown(ITestContext context) throws Throwable {
         assumeTeardown();
 

--- a/src/test/java/io/managed/services/test/ServiceAPIUnauthUserTest.java
+++ b/src/test/java/io/managed/services/test/ServiceAPIUnauthUserTest.java
@@ -53,7 +53,7 @@ public class ServiceAPIUnauthUserTest extends TestBase {
         "1eddbbmcV05FWDb8X4opshptnWDzAw4ZPhbjoTBhNEI2JbFssOSYpskNnkB4kKQb" +
         "BjVxAPldBNFwRKLOfvJNdY1jNurMY1xVMl2dbEpFBkqJf1lByU";
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT)
+    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
     public void teardown() throws Throwable {
         bwait(vertx.close());
     }


### PR DESCRIPTION
**Why**

if the bootstrap fails in one of the operations it needs to do the teardown is skip leaving some resources created by the bootstrap hanging around