### PR TITLE
fix: update service api to use new updated paths and allow unknonw fi…

### DIFF
--- a/src/main/java/io/managed/services/test/client/serviceapi/KafkaResponse.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/KafkaResponse.java
@@ -1,7 +1,9 @@
 package io.managed.services.test.client.serviceapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KafkaResponse {
     public String id;
     public String kind;
@@ -14,6 +16,7 @@ public class KafkaResponse {
     public String region;
     public String owner;
     public String name;
+    @JsonProperty("bootstrap_server_host")
     public String bootstrapServerHost;
     @JsonProperty("created_at")
     public String createdAt;

--- a/src/main/java/io/managed/services/test/client/serviceapi/KafkaUserMetricItem.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/KafkaUserMetricItem.java
@@ -1,14 +1,15 @@
 package io.managed.services.test.client.serviceapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KafkaUserMetricItem {
 
     public KafkaUserMetric metric;
 
-    @JsonProperty("Timestamp")
+    @JsonProperty("timestamp")
     public Double timestamp;
-    @JsonProperty("Value")
+    @JsonProperty("value")
     public Double value;
 }

--- a/src/main/java/io/managed/services/test/client/serviceapi/ServiceAPI.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/ServiceAPI.java
@@ -71,7 +71,7 @@ public class ServiceAPI extends BaseVertxClient {
     }
 
     public Future<ServiceAccount> createServiceAccount(CreateServiceAccountPayload payload) {
-        return retry(() -> client.post(API_BASE + "serviceaccounts")
+        return retry(() -> client.post(API_BASE + "service_accounts")
                 .authentication(token)
                 .sendJson(payload)
                 .compose(r -> assertResponse(r, HttpURLConnection.HTTP_ACCEPTED)) // TODO: report issue: swagger says 200
@@ -79,7 +79,7 @@ public class ServiceAPI extends BaseVertxClient {
     }
 
     public Future<ServiceAccountList> getListOfServiceAccounts() {
-        return retry(() -> client.get(API_BASE + "serviceaccounts")
+        return retry(() -> client.get(API_BASE + "service_accounts")
                 .authentication(token)
                 .send()
                 .compose(r -> assertResponse(r, HttpURLConnection.HTTP_OK))
@@ -87,7 +87,7 @@ public class ServiceAPI extends BaseVertxClient {
     }
 
     public Future<ServiceAccount> resetCredentialsServiceAccount(String id) {
-        return retry(() -> client.post(String.format(API_BASE + "serviceaccounts/%s/reset-credentials", id))
+        return retry(() -> client.post(String.format(API_BASE + "service_accounts/%s/reset_credentials", id))
                 .authentication(token)
                 .send()
                 .compose(r -> assertResponse(r, HttpURLConnection.HTTP_OK))
@@ -95,7 +95,7 @@ public class ServiceAPI extends BaseVertxClient {
     }
 
     public Future<Void> deleteServiceAccount(String id) {
-        return retry(() -> client.delete(String.format(API_BASE + "serviceaccounts/%s", id))
+        return retry(() -> client.delete(String.format(API_BASE + "service_accounts/%s", id))
                 .authentication(token)
                 .send()
                 .compose(r -> assertResponse(r, HttpURLConnection.HTTP_NO_CONTENT))

--- a/src/main/java/io/managed/services/test/client/serviceapi/ServiceAccount.java
+++ b/src/main/java/io/managed/services/test/client/serviceapi/ServiceAccount.java
@@ -1,14 +1,18 @@
 package io.managed.services.test.client.serviceapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceAccount {
     public String description;
     public String href;
     public String id;
     public String server;
     public String kind;
+    @JsonProperty("client_id")
     public String clientID;
+    @JsonProperty("client_secret")
     public String clientSecret;
     public String name;
     public String owner;


### PR DESCRIPTION
…elds in certain APIs

Recently we have introduced some changes in the kas-fleet-manager to ensure naming consistency. Mainly the changes include:

* all paths should use snake cases
* all field names should use snake cases

In order to keep backward compatibility, both old values and new values are going to be supported for a period of time. This is causing the E2E to fail because now there are some additional fields return for some of the endpoints (mainly the Kafkas and ServiceAccounts endpoints).

This PR updates the service API client to use the new paths, and also allow unknown fields for Kafkas and ServiceAccounts. We can remove the latter later on when the old fields are removed.

@b1zzu @kornys can you review this please? Thanks.