### PR TITLE
Cli logout pe canary replacement

### DIFF
--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -149,23 +149,6 @@ public class KafkaCLITest extends TestBase {
     }
 
     @Test(dependsOnMethods = "testLogin", timeOut = DEFAULT_TIMEOUT)
-    public void testLogout() throws Throwable {
-
-        LOGGER.info("verify that we are logged-in");
-        bwait(cli.listKafka()); // successfully run cli command while logged in
-
-        LOGGER.info("logout");
-        bwait(cli.logout());
-
-        LOGGER.info("verify that we are logged-in");
-        assertThrows(ProcessException.class, () -> bwait(cli.listKafka())); // unable to run the same command after logout
-
-        LOGGER.info("login back the CLI");
-        // after test we login back for sake of next tests.
-        bwait(CLIUtils.login(vertx, cli, Environment.SSO_USERNAME, Environment.SSO_PASSWORD));
-    }
-
-    @Test(dependsOnMethods = "testLogin", timeOut = DEFAULT_TIMEOUT)
     public void testCreateServiceAccount() throws Throwable {
 
         LOGGER.info("create a service account");
@@ -312,5 +295,18 @@ public class KafkaCLITest extends TestBase {
         bwait(cli.deleteKafka(kafkaInstance.id));
 
         bwait(waitForKafkaDelete(vertx, cli, kafkaInstance.name));
+    }
+
+    @Test(priority = 3, timeOut = DEFAULT_TIMEOUT)
+    public void testLogout() throws Throwable {
+
+        LOGGER.info("verify that we are logged-in");
+        bwait(cli.listKafka()); // successfully run cli command while logged in
+
+        LOGGER.info("logout");
+        bwait(cli.logout());
+
+        LOGGER.info("verify that we are logged-in");
+        assertThrows(ProcessException.class, () -> bwait(cli.listKafka())); // unable to run the same command after logout
     }
 }

--- a/src/test/java/io/managed/services/test/kafkainstances/KafkaAdminPermissionTest.java
+++ b/src/test/java/io/managed/services/test/kafkainstances/KafkaAdminPermissionTest.java
@@ -285,8 +285,9 @@ public class KafkaAdminPermissionTest extends TestBase {
         LOGGER.info("describe consumer groups: {}", r);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
-    public void testFailToDeleteActiveConsumerGroup() throws Throwable {
+    // test is postponed from others due to existence of many test that require presence of to be deleted consumer group
+    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    public void testDeleteConsumerGroup() throws Throwable {
 
         LOGGER.info("kafka-consumer-groups.sh --all-groups --delete  <permitted>, script representation test");
         LOGGER.info("deleting group");


### PR DESCRIPTION
**Use a different topic from the canary topic for the KafkaAdminPermissionTest**: temporary topic is created inside test and removed in clean up for easier Debug (in case Teardown is turned off)

**Automate CLI logout E2E test**: new testLogout is added, once check is done login is invoked again so we don't have to add unintuitive dependencies between test to keep this test last. 

