### PR TITLE
fix: update kafka create to use --name flag

### DIFF
--- a/src/main/java/io/managed/services/test/cli/CLI.java
+++ b/src/main/java/io/managed/services/test/cli/CLI.java
@@ -119,7 +119,7 @@ public class CLI {
     }
 
     public Future<KafkaResponse> createKafka(String name) {
-        return retry(() -> exec("kafka", "create", name)
+        return retry(() -> exec("kafka", "create", "--name", name)
             .map(p -> stdoutAsJson(p, KafkaResponse.class)));
     }
 


### PR DESCRIPTION
Since v0.25.0-beta5 the `kafka create` command now also requires a flag for "name".

https://github.com/redhat-developer/app-services-cli/releases/tag/v0.27.0-beta5