### PR TITLE
fix: wait for consumers in consumer group

### DIFF
--- a/src/test/java/io/managed/services/test/kafka/KafkaAdminAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaAdminAPITest.java
@@ -204,6 +204,9 @@ public class KafkaAdminAPITest extends TestBase {
         var group = KafkaInstanceApiUtils.waitForConsumerGroup(kafkaInstanceApi, TEST_GROUP_NAME);
         LOGGER.debug(group);
 
+        group = KafkaInstanceApiUtils.waitForConsumersInConsumerGroup(kafkaInstanceApi, group.getGroupId());
+        LOGGER.debug(group);
+
         assertEquals(group.getGroupId(), TEST_GROUP_NAME);
         assertTrue(group.getConsumers().size() > 0);
     }


### PR DESCRIPTION
It could take a couple of seconds for the api to report the
active consumers in a consumer group.