### PR TITLE
fix: close consumer in teardown

### DIFF
--- a/src/test/java/io/managed/services/test/kafka/KafkaAdminAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaAdminAPITest.java
@@ -97,6 +97,18 @@ public class KafkaAdminAPITest extends TestBase {
         } catch (Throwable t) {
             LOGGER.error("failed to clean service account: ", t);
         }
+
+        try {
+            bwait(kafkaConsumer.close());
+        } catch (Throwable t) {
+            LOGGER.error("failed to close consumer: ", t);
+        }
+
+        try {
+            bwait(vertx.close());
+        } catch (Throwable t) {
+            LOGGER.error("failed to close vertx: ", t);
+        }
     }
 
     @Test(timeOut = DEFAULT_TIMEOUT)


### PR DESCRIPTION
if the tests fails, and it doesn't reach the test where the
consumer is closed this will ensure that is going to be close
either-way