### PR TITLE
Disable canary tests until we find an alternative solution

### DIFF
--- a/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
+++ b/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
@@ -189,7 +189,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
     @Test(dependsOnMethods = {
         "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist",
         "testRecreateTheLongLiveServiceAccountIfItDoesNotExist"
-    }, timeOut = DEFAULT_TIMEOUT)
+    }, timeOut = DEFAULT_TIMEOUT, enabled = false)
     void testThatTheCanaryTopicExist() {
 
         var bootstrapHost = kafka.getBootstrapServerHost();
@@ -205,7 +205,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
     }
 
 
-    @Test(dependsOnMethods = "testThatTheCanaryTopicExist", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testThatTheCanaryTopicExist", timeOut = DEFAULT_TIMEOUT, enabled = false)
     void testCanaryLiveliness() throws Throwable {
 
         var bootstrapHost = kafka.getBootstrapServerHost();


### PR DESCRIPTION
The canary topic is not anymore visible to the instance owner therefore we have to find another way to perform the canary tool health check