### PR TITLE
refactor: remove time-out because of how TestNG handles them

### DIFF
--- a/src/test/java/io/managed/services/test/SSOAuthTest.java
+++ b/src/test/java/io/managed/services/test/SSOAuthTest.java
@@ -29,21 +29,21 @@ public class SSOAuthTest extends TestBase {
         assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testRedHatSSOLogin() throws Throwable {
         var auth = new KeycloakOAuth(Vertx.vertx(), Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
         bwait(auth.loginToRedHatSSO());
         LOGGER.info("user authenticated against: {}", Environment.REDHAT_SSO_URI);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testMASSSOLogin() throws Throwable {
         var auth2 = new KeycloakOAuth(Vertx.vertx(), Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
         bwait(auth2.loginToOpenshiftIdentity());
         LOGGER.info("user authenticated against: {}", Environment.OPENSHIFT_IDENTITY_URI);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testJoinedLogin() throws Throwable {
         var auth = new KeycloakOAuth(Vertx.vertx(), Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
 

--- a/src/test/java/io/managed/services/test/TestBase.java
+++ b/src/test/java/io/managed/services/test/TestBase.java
@@ -13,9 +13,6 @@ import org.testng.annotations.Listeners;
     PrometheusSuiteListener.class})
 public abstract class TestBase {
 
-    protected static final long MINUTES = 60 * 1000;
-    protected static final long DEFAULT_TIMEOUT = 3 * MINUTES;
-
     static {
         log.info("### Environment variables:");
         Environment.getValues().forEach((key, value) -> log.info("{}: {}", key, value));

--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -78,7 +78,7 @@ public class KafkaCLITest extends TestBase {
         assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @SneakyThrows
     public void clean() {
 
@@ -115,7 +115,7 @@ public class KafkaCLITest extends TestBase {
         bwait(vertx.close());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testDownloadCLI() {
 
@@ -131,7 +131,7 @@ public class KafkaCLITest extends TestBase {
     }
 
 
-    @Test(dependsOnMethods = "testDownloadCLI", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testDownloadCLI")
     @SneakyThrows
     public void testLogin() {
 
@@ -145,7 +145,7 @@ public class KafkaCLITest extends TestBase {
         cli.listKafka();
     }
 
-    @Test(dependsOnMethods = "testLogin", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testLogin")
     @SneakyThrows
     public void testCreateServiceAccount() {
 
@@ -163,7 +163,7 @@ public class KafkaCLITest extends TestBase {
         serviceAccount = sa.get();
     }
 
-    @Test(dependsOnMethods = "testCreateServiceAccount", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateServiceAccount")
     @SneakyThrows
     public void testDescribeServiceAccount() {
 
@@ -173,7 +173,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals(sa.getName(), SERVICE_ACCOUNT_NAME);
     }
 
-    @Test(dependsOnMethods = "testLogin", timeOut = 15 * MINUTES)
+    @Test(dependsOnMethods = "testLogin")
     @SneakyThrows
     public void testCreateKafkaInstance() {
 
@@ -186,7 +186,7 @@ public class KafkaCLITest extends TestBase {
         LOGGER.debug(kafka);
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance")
     @SneakyThrows
     public void testDescribeKafkaInstance() {
 
@@ -197,7 +197,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals("ready", k.getStatus());
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance")
     @SneakyThrows
     public void testListKafkaInstances() {
 
@@ -210,7 +210,7 @@ public class KafkaCLITest extends TestBase {
         assertTrue(exists.isPresent());
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance")
     @SneakyThrows
     public void testSearchKafkaByName() {
 
@@ -222,7 +222,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals(exists.get().getName(), KAFKA_INSTANCE_NAME);
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance")
     @SneakyThrows
     public void testCreateTopic() {
 
@@ -234,7 +234,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals(Objects.requireNonNull(topic.getPartitions()).size(), DEFAULT_PARTITIONS);
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     @SneakyThrows
     public void testListTopics() {
 
@@ -248,7 +248,7 @@ public class KafkaCLITest extends TestBase {
     }
 
 
-    @Test(dependsOnMethods = {"testCreateTopic", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopic", "testCreateServiceAccount"})
     @SneakyThrows
     public void testKafkaInstanceTopic() {
 
@@ -267,7 +267,7 @@ public class KafkaCLITest extends TestBase {
             100));
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     @SneakyThrows
     public void testUpdateTopic() {
 
@@ -289,7 +289,7 @@ public class KafkaCLITest extends TestBase {
         topic = t;
     }
 
-    @Test(dependsOnMethods = "testUpdateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testUpdateTopic")
     @SneakyThrows
     public void testDescribeUpdatedTopic() {
 
@@ -314,7 +314,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals(retentionValue.get().getValue(), retentionTime);
     }
 
-    @Test(dependsOnMethods = {"testUpdateTopic", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testUpdateTopic", "testCreateServiceAccount"})
     @SneakyThrows
     public void testKafkaInstanceUpdatedTopic() {
 
@@ -333,7 +333,7 @@ public class KafkaCLITest extends TestBase {
             100));
     }
 
-    @Test(dependsOnMethods = {"testCreateTopic", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopic", "testCreateServiceAccount"})
     @SneakyThrows
     public void testDescribeConsumerGroup() {
 
@@ -351,7 +351,7 @@ public class KafkaCLITest extends TestBase {
         assertEquals(group.getGroupId(), CONSUMER_GROUP_NAME);
     }
 
-    @Test(dependsOnMethods = "testDescribeConsumerGroup", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testDescribeConsumerGroup")
     @SneakyThrows
     public void testListConsumerGroups() {
         var groups = cli.listConsumerGroups();
@@ -365,7 +365,7 @@ public class KafkaCLITest extends TestBase {
         assertTrue(filteredGroup.isPresent());
     }
 
-    @Test(dependsOnMethods = "testDescribeConsumerGroup", priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testDescribeConsumerGroup", priority = 1)
     @SneakyThrows
     public void testDeleteConsumerGroup() {
 
@@ -376,7 +376,7 @@ public class KafkaCLITest extends TestBase {
             () -> cli.describeConsumerGroup(CONSUMER_GROUP_NAME));
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", priority = 2, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic", priority = 2)
     @SneakyThrows
     public void testDeleteTopic() {
 
@@ -387,7 +387,7 @@ public class KafkaCLITest extends TestBase {
             () -> cli.describeTopic(TOPIC_NAME));
     }
 
-    @Test(dependsOnMethods = "testCreateServiceAccount", priority = 2, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateServiceAccount", priority = 2)
     @SneakyThrows
     public void testDeleteServiceAccount() {
 
@@ -398,7 +398,7 @@ public class KafkaCLITest extends TestBase {
             () -> cli.describeServiceAccount(serviceAccount.getId()));
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", priority = 3, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance", priority = 3)
     @SneakyThrows
     public void testDeleteKafkaInstance() {
 
@@ -408,7 +408,7 @@ public class KafkaCLITest extends TestBase {
         CLIUtils.waitUntilKafkaIsDeleted(cli, kafka.getId());
     }
 
-    @Test(dependsOnMethods = "testLogin", priority = 3, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testLogin", priority = 3)
     @SneakyThrows
     public void testLogout() {
 

--- a/src/test/java/io/managed/services/test/devexp/KafkaOperatorTest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaOperatorTest.java
@@ -84,7 +84,7 @@ public class KafkaOperatorTest extends TestBase {
     private final static String CLOUD_SERVICES_REQUEST_NAME = "mk-e2e-kafka-request";
     private final static String KAFKA_CONNECTION_NAME = "mk-e2e-kafka-connection";
 
-    @BeforeClass(timeOut = 15 * MINUTES)
+    @BeforeClass
     @SneakyThrows
     public void bootstrap() {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
@@ -161,7 +161,7 @@ public class KafkaOperatorTest extends TestBase {
 
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown(ITestContext context) {
         assumeTeardown();
 
@@ -209,7 +209,7 @@ public class KafkaOperatorTest extends TestBase {
         }
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testCreateAccessTokenSecret() {
 
         // Create Secret
@@ -220,7 +220,7 @@ public class KafkaOperatorTest extends TestBase {
         oc.secrets().create(OperatorUtils.buildSecret(ACCESS_TOKEN_SECRET_NAME, data));
     }
 
-    @Test(dependsOnMethods = "testCreateAccessTokenSecret", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateAccessTokenSecret")
     public void testCreateCloudServiceAccountRequest() throws Throwable {
 
         var a = new CloudServiceAccountRequest();
@@ -245,7 +245,7 @@ public class KafkaOperatorTest extends TestBase {
         LOGGER.info("CloudServiceAccountRequest is created");
     }
 
-    @Test(dependsOnMethods = "testCreateAccessTokenSecret", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateAccessTokenSecret")
     public void testCreateCloudServicesRequest() throws Throwable {
 
         var k = new CloudServicesRequest();
@@ -274,7 +274,7 @@ public class KafkaOperatorTest extends TestBase {
         LOGGER.info("CloudServicesRequest is completed");
     }
 
-    @Test(dependsOnMethods = {"testCreateCloudServiceAccountRequest", "testCreateCloudServicesRequest"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateCloudServiceAccountRequest", "testCreateCloudServicesRequest"})
     public void testCreateManagedKafkaConnection() throws Throwable {
 
         var userKafka = cloudServicesRequest.getStatus().getUserKafkas().stream()

--- a/src/test/java/io/managed/services/test/kafka/KafkaAdminPermissionTest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaAdminPermissionTest.java
@@ -58,7 +58,7 @@ public class KafkaAdminPermissionTest extends TestBase {
     private SecurityMgmtApi securityMgmtApi;
     private KafkaAdmin admin;
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @SneakyThrows
     public void teardown() {
 
@@ -94,7 +94,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         bwait(vertx.close());
     }
 
-    @BeforeClass(timeOut = 15 * MINUTES)
+    @BeforeClass
     public void bootstrap() throws Throwable {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
         assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
@@ -132,7 +132,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         bwait(consumer.asyncClose());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToCreateTopic() {
 
         log.info("kafka-topics.sh --create <Permitted>, script representation test");
@@ -141,7 +141,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("topic successfully created: {}", TOPIC_NAME);
     }
 
-    @Test(dependsOnMethods = "testAllowedToCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testAllowedToCreateTopic")
     public void testAllowedToListTopic() {
 
         log.info("kafka-topics.sh --list <Permitted>, script representation test");
@@ -150,7 +150,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("topics successfully listed, response contains {} topic/s", r.size());
     }
 
-    @Test(dependsOnMethods = "testAllowedToCreateTopic", priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testAllowedToCreateTopic", priority = 1)
     public void testAllowedToDeleteTopic() {
 
         log.info("kafka-topics.sh --delete <Permitted>, script representation test");
@@ -171,7 +171,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         };
     }
 
-    @Test(dataProvider = "aclAddCmdProvider", timeOut = DEFAULT_TIMEOUT)
+    @Test(dataProvider = "aclAddCmdProvider")
     public void testForbiddenToAlterACLResource(String testName, ResourceType resourceType) {
         log.info("kafka-acls.sh {} <Forbidden>, script representation test", testName);
         assertThrows(ClusterAuthorizationException.class, () -> admin.addAclResource(resourceType));
@@ -189,7 +189,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         };
     }
 
-    @Test(dataProvider = "aclListCmdProvider", timeOut = DEFAULT_TIMEOUT)
+    @Test(dataProvider = "aclListCmdProvider")
     public void testAllowedToListACLResource(String testName, ResourceType resourceType) {
         log.info("kafka-acls.sh {} <Forbidden>, script representation test", testName);
         var r = admin.listAclResource(resourceType);
@@ -208,13 +208,13 @@ public class KafkaAdminPermissionTest extends TestBase {
         };
     }
 
-    @Test(dataProvider = "aclDeleteCmdProvider", timeOut = DEFAULT_TIMEOUT)
+    @Test(dataProvider = "aclDeleteCmdProvider")
     public void testForbiddenToDeleteACLResource(String testName, ResourceType resourceType) {
         log.info("kafka-acls.sh {} <Forbidden>, script representation test", testName);
         assertThrows(ClusterAuthorizationException.class, () -> admin.deleteAclResource(resourceType));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToDescribeTopicConfiguration() {
 
         log.info("kafka-configs.sh --describe --entity-type topics <permitted>, script representation test");
@@ -223,7 +223,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("response size: {}", r.size());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @Ignore
     public void testAllowedToDescribeUserConfiguration() {
 
@@ -243,20 +243,20 @@ public class KafkaAdminPermissionTest extends TestBase {
         };
     }
 
-    @Test(dataProvider = "configureBrokerCmdProvider", timeOut = DEFAULT_TIMEOUT)
+    @Test(dataProvider = "configureBrokerCmdProvider")
     public void testForbiddenToAlterBrokerConfig(String testName, ConfigResource.Type resourceType, AlterConfigOp.OpType opType) {
         log.info("kafka-config.sh {} <allowed>, script representation test", testName);
         assertThrows(ClusterAuthorizationException.class, () -> admin.configureBrokerResource(resourceType, opType, "0"));
     }
 
-    @Test(dependsOnMethods = "testAllowedToCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testAllowedToCreateTopic")
     public void testAllowedToDeleteTopicConfig() {
 
         log.info("kafka-config.sh --alter --entity-type topics --delete-config <allowed>, script representation test");
         admin.configureBrokerResource(ConfigResource.Type.TOPIC, AlterConfigOp.OpType.DELETE, TOPIC_NAME);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToDescribeBrokerConfig() {
 
         log.info("kafka-configs.sh --describe --entity-type broker <forbidden>, script representation test");
@@ -264,7 +264,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         assertThrows(ClusterAuthorizationException.class, () -> admin.getConfigurationBroker("0"));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToDescribeBrokerLoggerConfig() {
 
         log.info("kafka-configs.sh --describe --entity-type brokerLogger <forbidden>, script representation test");
@@ -272,7 +272,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         assertThrows(ClusterAuthorizationException.class, () -> admin.getConfigurationBrokerLogger("0"));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @Ignore
     public void testForbiddenToAlterUserConfig() {
 
@@ -281,7 +281,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         assertThrows(InvalidRequestException.class, () -> admin.alterConfigurationUser());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToListConsumerGroups() {
 
         log.info("kafka-consumer-groups.sh --list <permitted>, script representation test");
@@ -290,7 +290,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("list consumer groups: {}", r);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToDescribeConsumerGroup() {
 
         log.info("kafka-consumer-groups.sh --group --describe <permitted>, script representation test");
@@ -300,7 +300,7 @@ public class KafkaAdminPermissionTest extends TestBase {
     }
 
     // test is postponed from others due to existence of many test that require presence of to be deleted consumer group
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     public void testDeleteConsumerGroup() {
 
         log.info("kafka-consumer-groups.sh --all-groups --delete  <permitted>, script representation test");
@@ -309,7 +309,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         admin.deleteConsumerGroups(TEST_GROUP_ID);
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToResetConsumerGroupOffset() {
 
         log.info("kafka-consumer-groups.sh --all-groups --reset-offsets --execute --all-groups --all-topics  <permitted>, script representation test");
@@ -317,7 +317,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("offset successfully reset");
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToDeleteConsumerGroupOffset() {
 
         log.info("kafka-consumer-groups.sh --delete-offsets  <permitted>, script representation test");
@@ -325,7 +325,7 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("offset successfully deleted");
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAllowedToDeleteRecords() {
 
         log.info("kafka-delete-records.sh --offset-json-file <permitted>, script representation test");
@@ -333,42 +333,42 @@ public class KafkaAdminPermissionTest extends TestBase {
         log.info("record successfully deleted");
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToUncleanLeaderElection() {
 
         log.info("kafka-leader-election.sh <forbidden>, script representation test");
         assertThrows(ClusterAuthorizationException.class, () -> admin.electLeader(ElectionType.UNCLEAN, TOPIC_NAME_FOR_GROUPS));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToDescribeLogDirs() {
 
         log.info("kafka-log-dirs.sh --describe <forbidden>, script representation test");
         assertThrows(ClusterAuthorizationException.class, () -> admin.logDirs());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToAlterPreferredReplicaElection() {
 
         log.info("kafka-preferred-replica-election.sh <forbidden>, script representation test");
         assertThrows(ClusterAuthorizationException.class, () -> admin.electLeader(ElectionType.PREFERRED, TOPIC_NAME_FOR_GROUPS));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToReassignPartitions() {
 
         log.info("kafka-reassign-partitions.sh <forbidden>, script representation test");
         assertThrows(ClusterAuthorizationException.class, () -> admin.reassignPartitions(TOPIC_NAME_FOR_GROUPS));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToCreateDelegationToken() {
 
         log.info("kafka-delegation-tokens.sh create <forbidden>, script representation test");
         assertThrows(DelegationTokenDisabledException.class, () -> admin.createDelegationToken());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testForbiddenToDescribeDelegationToken() {
 
         log.info("kafka-delegation-tokens.sh describe <forbidden>, script representation test");

--- a/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
@@ -70,7 +70,7 @@ public class KafkaInstanceAPITest extends TestBase {
 
     // TODO: Test update topic with random values
 
-    @BeforeClass(timeOut = 15 * MINUTES)
+    @BeforeClass
     @SneakyThrows
     public void bootstrap() {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
@@ -88,7 +88,7 @@ public class KafkaInstanceAPITest extends TestBase {
         LOGGER.info("kafka instance api client initialized");
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown() {
         assumeTeardown();
 
@@ -119,7 +119,7 @@ public class KafkaInstanceAPITest extends TestBase {
         }
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testFailToCallAPIIfUserBelongsToADifferentOrganization() {
 
@@ -129,7 +129,7 @@ public class KafkaInstanceAPITest extends TestBase {
     }
 
     // See: https://issues.redhat.com/browse/MGDSTRM-5635
-    @Test(timeOut = DEFAULT_TIMEOUT, enabled = false)
+    @Test(enabled = false)
     @SneakyThrows
     public void testFailToCallAPIIfUserDoesNotOwnTheKafkaInstance() {
 
@@ -138,7 +138,7 @@ public class KafkaInstanceAPITest extends TestBase {
         assertThrows(ApiUnauthorizedException.class, () -> kafkaInstanceApi.getTopics());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testFailToCallAPIIfTokenIsInvalid() {
 
@@ -147,7 +147,7 @@ public class KafkaInstanceAPITest extends TestBase {
         assertThrows(ApiUnauthorizedException.class, () -> kafkaInstanceApi.getTopics());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testCreateTopic() {
 
@@ -163,7 +163,7 @@ public class KafkaInstanceAPITest extends TestBase {
         LOGGER.debug(topic);
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     public void testFailToCreateTopicIfItAlreadyExist() {
         // create existing topic should fail
         var payload = new NewTopicInput()
@@ -173,7 +173,7 @@ public class KafkaInstanceAPITest extends TestBase {
             () -> kafkaInstanceApi.createTopic(payload));
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     @SneakyThrows
     public void testGetTopicByName() {
         var topic = kafkaInstanceApi.getTopic(TEST_TOPIC_NAME);
@@ -181,14 +181,14 @@ public class KafkaInstanceAPITest extends TestBase {
         assertEquals(topic.getName(), TEST_TOPIC_NAME);
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     public void testFailToGetTopicIfItDoesNotExist() {
         // get none existing topic should fail
         assertThrows(ApiNotFoundException.class,
             () -> kafkaInstanceApi.getTopic(TEST_NOT_EXISTING_TOPIC_NAME));
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     @SneakyThrows
     public void tetGetAllTopics() {
         var topics = kafkaInstanceApi.getTopics();
@@ -202,14 +202,14 @@ public class KafkaInstanceAPITest extends TestBase {
         assertTrue(filteredTopics.isPresent());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testFailToDeleteTopicIfItDoesNotExist() {
         // deleting not existing topic should fail
         assertThrows(ApiNotFoundException.class,
             () -> kafkaInstanceApi.deleteTopic(TEST_NOT_EXISTING_TOPIC_NAME));
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic")
     @SneakyThrows
     public void testConsumerGroup() {
         LOGGER.info("create or retrieve service account '{}'", SERVICE_ACCOUNT_NAME);
@@ -232,7 +232,7 @@ public class KafkaInstanceAPITest extends TestBase {
         assertTrue(group.getConsumers().size() > 0);
     }
 
-    @Test(dependsOnMethods = "testConsumerGroup", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testConsumerGroup")
     @SneakyThrows
     public void testGetAllConsumerGroups() {
         var groups = kafkaInstanceApi.getConsumerGroups();
@@ -246,28 +246,28 @@ public class KafkaInstanceAPITest extends TestBase {
         assertTrue(filteredGroup.isPresent());
     }
 
-    @Test(dependsOnMethods = "testConsumerGroup", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testConsumerGroup")
     public void testFailToGetConsumerGroupIfItDoesNotExist() {
         // get consumer group non-existing consumer group should fail
         assertThrows(ApiNotFoundException.class,
             () -> kafkaInstanceApi.getConsumerGroupById(TEST_NOT_EXISTING_GROUP_NAME));
     }
 
-    @Test(dependsOnMethods = "testConsumerGroup", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testConsumerGroup")
     public void testFailToDeleteConsumerGroupIfItIsActive() {
         // deleting active consumer group should fail
         assertThrows(ApiLockedException.class,
             () -> kafkaInstanceApi.deleteConsumerGroupById(TEST_GROUP_NAME));
     }
 
-    @Test(dependsOnMethods = "testConsumerGroup", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testConsumerGroup")
     public void testFailToDeleteConsumerGroupIfItDoesNotExist() {
         // deleting not existing consumer group should fail
         assertThrows(ApiNotFoundException.class,
             () -> kafkaInstanceApi.deleteConsumerGroupById(TEST_NOT_EXISTING_GROUP_NAME));
     }
 
-    @Test(dependsOnMethods = "testConsumerGroup", priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testConsumerGroup", priority = 1)
     public void testDeleteConsumerGroup() throws Throwable {
         LOGGER.info("close kafka consumer");
         bwait(kafkaConsumer.asyncClose());
@@ -281,7 +281,7 @@ public class KafkaInstanceAPITest extends TestBase {
         LOGGER.info("consumer group '{}' not found", TEST_GROUP_NAME);
     }
 
-    @Test(dependsOnMethods = "testCreateTopic", priority = 2, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateTopic", priority = 2)
     public void testDeleteTopic() throws Throwable {
         kafkaInstanceApi.deleteTopic(TEST_TOPIC_NAME);
         LOGGER.info("topic '{}' deleted", TEST_TOPIC_NAME);

--- a/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPIPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPIPermissionsTest.java
@@ -54,7 +54,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
 
     private KafkaRequest kafka;
 
-    @BeforeClass(timeOut = 15 * MINUTES)
+    @BeforeClass
     @SneakyThrows
     public void bootstrap() {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
@@ -80,7 +80,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
         kafka = KafkaMgmtApiUtils.applyKafkaInstance(mainAPI.kafkaMgmt(), KAFKA_INSTANCE_NAME);
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @SneakyThrows
     public void teardown() {
         assumeTeardown();
@@ -104,7 +104,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
         }
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testSecondaryUserCanReadTheKafkaInstance() {
 
@@ -121,7 +121,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
     }
 
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testAlienUserCanNotReadTheKafkaInstance() {
 
@@ -161,7 +161,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
      * kafka instance created by the main user
      */
     // See: https://issues.redhat.com/browse/MGDSTRM-5635
-    @Test(timeOut = DEFAULT_TIMEOUT, enabled = false)
+    @Test(enabled = false)
     @SneakyThrows
     public void testSecondaryUserServiceAccountCanNotCreateTopicOnTheKafkaInstance() {
 
@@ -188,7 +188,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
         admin.close();
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testAlienUserCanNotCreateTopicOnTheKafkaInstance() {
 
@@ -207,7 +207,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
     /**
      * A user in org A is not allowed to create topic to produce and consume messages on a kafka instance in org B
      */
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testAlienUserServiceAccountCanNotCreateTopicOnTheKafkaInstance() {
 
@@ -235,25 +235,25 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
         admin.close();
     }
 
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     public void testSecondaryUserCanNotDeleteTheKafkaInstance() {
         // should failKafkaControlManagerAPIPermissionsTestKafkaControlManagerAPIPermissionsTest
         assertThrows(ApiNotFoundException.class, () -> secondaryAPI.kafkaMgmt().deleteKafkaById(kafka.getId(), true));
     }
 
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     public void testAlienUserCanNotDeleteTheKafkaInstance() {
         // should fail
         assertThrows(ApiNotFoundException.class, () -> alienAPI.kafkaMgmt().deleteKafkaById(kafka.getId(), true));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testUnauthenticatedUserWithFakeToken() {
         var api = new ApplicationServicesApi(Environment.OPENSHIFT_API_URI, TestUtils.FAKE_TOKEN);
         assertThrows(ApiUnauthorizedException.class, () -> api.kafkaMgmt().getKafkas(null, null, null, null));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testUnauthenticatedUserWithoutToken() {
         var api = new ApplicationServicesApi(Environment.OPENSHIFT_API_URI, "");
         assertThrows(ApiUnauthorizedException.class, () -> api.kafkaMgmt().getKafkas(null, null, null, null));

--- a/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
@@ -82,7 +82,7 @@ public class KafkaMgmtAPITest extends TestBase {
         kafkaMgmtApi = apps.kafkaMgmt();
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown() {
 
         // delete kafka instance
@@ -106,7 +106,7 @@ public class KafkaMgmtAPITest extends TestBase {
         }
     }
 
-    @Test(timeOut = 15 * MINUTES)
+    @Test
     @SneakyThrows
     public void testCreateKafkaInstance() {
 
@@ -123,7 +123,7 @@ public class KafkaMgmtAPITest extends TestBase {
         kafka = KafkaMgmtApiUtils.waitUntilKafkaIsReady(kafkaMgmtApi, k.getId());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testCreateServiceAccount() {
 
@@ -132,7 +132,7 @@ public class KafkaMgmtAPITest extends TestBase {
         serviceAccount = securityMgmtApi.createServiceAccount(new ServiceAccountRequest().name(SERVICE_ACCOUNT_NAME));
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateKafkaInstance")
     @SneakyThrows
     public void testCreateTopics() {
 
@@ -152,7 +152,7 @@ public class KafkaMgmtAPITest extends TestBase {
         kafkaInstanceApi.createTopic(metricTopicPayload);
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"})
     @SneakyThrows
     public void testMessageInTotalMetric() {
 
@@ -160,7 +160,7 @@ public class KafkaMgmtAPITest extends TestBase {
         KafkaMgmtMetricsUtils.testMessageInTotalMetric(kafkaMgmtApi, kafka, serviceAccount, TOPIC_NAME);
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"})
     @SneakyThrows
     public void testMessagingKafkaInstanceUsingOAuth() {
 
@@ -180,7 +180,7 @@ public class KafkaMgmtAPITest extends TestBase {
             KafkaAuthMethod.OAUTH));
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"})
     @SneakyThrows
     public void testFailedToMessageKafkaInstanceUsingOAuthAndFakeSecret() {
 
@@ -199,7 +199,7 @@ public class KafkaMgmtAPITest extends TestBase {
             KafkaAuthMethod.OAUTH)));
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"})
     @SneakyThrows
     public void testMessagingKafkaInstanceUsingPlainAuth() {
 
@@ -219,7 +219,7 @@ public class KafkaMgmtAPITest extends TestBase {
             KafkaAuthMethod.PLAIN));
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateServiceAccount"})
     @SneakyThrows
     public void testFailedToMessageKafkaInstanceUsingPlainAuthAndFakeSecret() {
 
@@ -238,7 +238,7 @@ public class KafkaMgmtAPITest extends TestBase {
             KafkaAuthMethod.PLAIN)));
     }
 
-    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateKafkaInstance"})
     @SneakyThrows
     public void testListAndSearchKafkaInstance() {
 
@@ -267,7 +267,7 @@ public class KafkaMgmtAPITest extends TestBase {
         assertEquals(kafkaOptional.get().getName(), KAFKA_INSTANCE_NAME);
     }
 
-    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateKafkaInstance"})
     public void testFailToCreateKafkaInstanceIfItAlreadyExist() {
 
         // Create Kafka Instance with existing name
@@ -281,7 +281,7 @@ public class KafkaMgmtAPITest extends TestBase {
         assertThrows(ApiConflictException.class, () -> kafkaMgmtApi.createKafka(true, payload));
     }
 
-    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, priority = 1)
     @SneakyThrows
     public void testDeleteKafkaInstance() {
 
@@ -318,7 +318,7 @@ public class KafkaMgmtAPITest extends TestBase {
         bwait(producer.asyncClose());
     }
 
-    @Test(priority = 2, timeOut = 10 * DEFAULT_TIMEOUT)
+    @Test(priority = 2)
     @SneakyThrows
     public void testDeleteProvisioningKafkaInstance() {
 

--- a/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
+++ b/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
@@ -86,7 +86,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         this.securityMgmtApi = apps.securityMgmt();
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testThatTheLongLiveKafkaInstanceAlreadyExist() {
 
@@ -99,7 +99,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         LOGGER.debug(kafka);
     }
 
-    @Test(priority = 1, timeOut = 15 * MINUTES)
+    @Test(priority = 1)
     @SneakyThrows
     public void testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist() {
         // recreate the instance only if it doesn't exist
@@ -113,7 +113,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
             Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     @SneakyThrows
     public void testThatTheLongLiveServiceAccountAlreadyExist() {
 
@@ -128,7 +128,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
     }
 
 
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     @SneakyThrows
     public void testRecreateTheLongLiveServiceAccountIfItDoesNotExist() {
         // recreate the account only if it doesn't exist
@@ -151,7 +151,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         return map;
     }
 
-    @Test(dependsOnMethods = "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist")
     public void testThatAllLongLiveTopicsAlreadyExist() throws Throwable {
 
         final var expectedTopics = expectedTopics();
@@ -162,7 +162,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         assertTrue(expectedTopics.isEmpty(), message("the topics '{}' don't exist", expectedTopics.keySet()));
     }
 
-    @Test(priority = 2, dependsOnMethods = "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist", timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 2, dependsOnMethods = "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist")
     @SneakyThrows
     public void testRecreateLongLiveTopicsIfTheyDoNotExist() {
 
@@ -189,7 +189,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
     @Test(dependsOnMethods = {
         "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist",
         "testRecreateTheLongLiveServiceAccountIfItDoesNotExist"
-    }, timeOut = DEFAULT_TIMEOUT, enabled = false)
+    }, enabled = false)
     void testThatTheCanaryTopicExist() {
 
         var bootstrapHost = kafka.getBootstrapServerHost();
@@ -205,7 +205,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
     }
 
 
-    @Test(dependsOnMethods = "testThatTheCanaryTopicExist", timeOut = DEFAULT_TIMEOUT, enabled = false)
+    @Test(dependsOnMethods = "testThatTheCanaryTopicExist", enabled = false)
     void testCanaryLiveliness() throws Throwable {
 
         var bootstrapHost = kafka.getBootstrapServerHost();
@@ -233,7 +233,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist",
         "testRecreateLongLiveTopicsIfTheyDoNotExist",
         "testRecreateTheLongLiveServiceAccountIfItDoesNotExist"
-    }, timeOut = DEFAULT_TIMEOUT)
+    })
     public void testProduceAndConsumeKafkaMessages() throws Throwable {
 
         String bootstrapHost = kafka.getBootstrapServerHost();
@@ -255,7 +255,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist",
         "testRecreateLongLiveTopicsIfTheyDoNotExist",
         "testRecreateTheLongLiveServiceAccountIfItDoesNotExist"
-    }, timeOut = DEFAULT_TIMEOUT)
+    })
     void testTopicWithThreePartitionsAndThreeConsumers() throws Throwable {
 
         var bootstrapHost = kafka.getBootstrapServerHost();
@@ -279,7 +279,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
         "testRecreateTheLongLiveKafkaInstanceIfItDoesNotExist",
         "testRecreateLongLiveTopicsIfTheyDoNotExist",
         "testRecreateTheLongLiveServiceAccountIfItDoesNotExist"
-    }, timeOut = DEFAULT_TIMEOUT)
+    })
     public void testMessageInTotalMetric() throws Throwable {
 
         LOGGER.info("test message in total metric");

--- a/src/test/java/io/managed/services/test/quickstarts/QuarkusApplicationTest.java
+++ b/src/test/java/io/managed/services/test/quickstarts/QuarkusApplicationTest.java
@@ -107,7 +107,7 @@ public class QuarkusApplicationTest extends TestBase {
     private KafkaRequest kafka;
     private Route route;
 
-    @BeforeClass(timeOut = 15 * MINUTES)
+    @BeforeClass
     @SneakyThrows
     public void bootstrap() {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
@@ -276,7 +276,7 @@ public class QuarkusApplicationTest extends TestBase {
         return Future.succeededFuture();
     }
 
-    @AfterClass(timeOut = 5 * MINUTES, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown(ITestContext context) throws Throwable {
         assumeTeardown();
 
@@ -347,7 +347,7 @@ public class QuarkusApplicationTest extends TestBase {
         bwait(vertx.close());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testCLIConnectCluster() throws Throwable {
         cleanAccessTokenSecret();
         cleanKafkaConnection();
@@ -369,7 +369,7 @@ public class QuarkusApplicationTest extends TestBase {
         cli.connectCluster(KeycloakOAuth.getRefreshToken(user), kubeconfgipath);
     }
 
-    @Test(dependsOnMethods = "testCLIConnectCluster", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCLIConnectCluster")
     public void testDeployQuarkusApplication() {
 
         // TODO: Deploy the application from https://raw.githubusercontent.com/redhat-developer/app-services-guides/main/code-examples/quarkus-kafka-quickstart/.kubernetes/kubernetes.yml
@@ -382,7 +382,7 @@ public class QuarkusApplicationTest extends TestBase {
         LOGGER.info("app deployed to: {}", route.getSpec().getHost());
     }
 
-    @Test(dependsOnMethods = "testDeployQuarkusApplication", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testDeployQuarkusApplication")
     public void testCreateServiceBinding() throws Throwable {
         cleanServiceBinding();
 
@@ -454,7 +454,7 @@ public class QuarkusApplicationTest extends TestBase {
         bwait(waitFor(vertx, "service binding to be ready", ofSeconds(3), ofMinutes(1), serviceBindingIsReady));
     }
 
-    @Test(dependsOnMethods = "testCreateServiceBinding", timeOut = 5 * MINUTES)
+    @Test(dependsOnMethods = "testCreateServiceBinding")
     public void testQuarkusApplication() throws Throwable {
 
         var endpoint = String.format("https://%s", route.getSpec().getHost());

--- a/src/test/java/io/managed/services/test/registry/RegistryKafkaIntegrationTest.java
+++ b/src/test/java/io/managed/services/test/registry/RegistryKafkaIntegrationTest.java
@@ -73,7 +73,7 @@ public class RegistryKafkaIntegrationTest extends TestBase {
     private KafkaRequest kafka;
     private ServiceAccount serviceAccount;
 
-    @BeforeClass(timeOut = 20 * MINUTES)
+    @BeforeClass
     public void bootstrap() throws Throwable {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
         assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
@@ -119,7 +119,7 @@ public class RegistryKafkaIntegrationTest extends TestBase {
         registryClient.createRoleMapping(role);
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown() throws Throwable {
         assumeTeardown();
 
@@ -144,7 +144,7 @@ public class RegistryKafkaIntegrationTest extends TestBase {
         bwait(vertx.close());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testProduceConsumeAvroMessageWithServiceRegistry() throws Throwable {
 
         // producer

--- a/src/test/java/io/managed/services/test/registry/RegistryMgmtAPIPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/registry/RegistryMgmtAPIPermissionsTest.java
@@ -83,7 +83,7 @@ public class RegistryMgmtAPIPermissionsTest extends TestBase {
             Environment.ALIEN_PASSWORD));
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown() throws Throwable {
         assumeTeardown();
 
@@ -96,13 +96,13 @@ public class RegistryMgmtAPIPermissionsTest extends TestBase {
         bwait(vertx.close());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testSecondaryUserCanReadTheRegistry() throws ApiGenericException {
         var r = secondaryRegistryMgmtApi.getRegistry(registry.getId());
         assertEquals(r.getName(), registry.getName());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testUserCanReadTheRegistry() throws ApiGenericException {
         LOGGER.info("registries: {}", Json.encode(registryMgmtApi.getRegistries(null, null, null, null)));
         LOGGER.info("registry: {}", Json.encode(registry));
@@ -110,12 +110,12 @@ public class RegistryMgmtAPIPermissionsTest extends TestBase {
         assertEquals(r.getName(), registry.getName());
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAlienUserCanNotReadTheRegistry() {
         assertThrows(ApiNotFoundException.class, () -> alienRegistryMgmtApi.getRegistry(registry.getId()));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testAlienUserCanNotCreateArtifactOnTheRegistry() throws Throwable {
         var registryClient = bwait(registryClient(vertx, registry.getRegistryUrl(),
             Environment.ALIEN_USERNAME,
@@ -124,24 +124,24 @@ public class RegistryMgmtAPIPermissionsTest extends TestBase {
         assertThrows(ForbiddenException.class, () -> registryClient.createArtifact(null, null, IOUtils.toInputStream(ARTIFACT_SCHEMA, StandardCharsets.UTF_8)));
     }
 
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     public void testSecondaryUserCanNotDeleteTheRegistry() {
         assertThrows(ApiForbiddenException.class, () -> secondaryRegistryMgmtApi.deleteRegistry(registry.getId()));
     }
 
-    @Test(priority = 1, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 1)
     public void testAlienUserCanNotDeleteTheRegistry() {
         assertThrows(ApiForbiddenException.class, () -> alienRegistryMgmtApi.deleteRegistry(registry.getId()));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testUnauthenticatedUserWithFakeToken() {
         var user = User.fromToken(TestUtils.FAKE_TOKEN);
         var api = registryMgmtApi(Environment.OPENSHIFT_API_URI, user);
         assertThrows(ApiUnauthorizedException.class, () -> api.getRegistries(null, null, null, null));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testUnauthenticatedUserWithoutToken() {
         var user = User.fromToken("");
         var api = registryMgmtApi(Environment.OPENSHIFT_API_URI, user);

--- a/src/test/java/io/managed/services/test/registry/RegistryMgmtAPITest.java
+++ b/src/test/java/io/managed/services/test/registry/RegistryMgmtAPITest.java
@@ -58,7 +58,7 @@ public class RegistryMgmtAPITest extends TestBase {
             Environment.PRIMARY_PASSWORD));
     }
 
-    @AfterClass(timeOut = DEFAULT_TIMEOUT, alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void teardown() {
         assumeTeardown();
 
@@ -75,7 +75,7 @@ public class RegistryMgmtAPITest extends TestBase {
         }
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT)
+    @Test
     public void testCreateRegistry() throws Exception {
 
         var registryCreateRest = new RegistryCreateRest()
@@ -93,7 +93,7 @@ public class RegistryMgmtAPITest extends TestBase {
         this.registry = registry;
     }
 
-    @Test(dependsOnMethods = "testCreateRegistry", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateRegistry")
     public void testCreateArtifact() throws Throwable {
         var registryClient = bwait(registryClient(Vertx.vertx(), registry.getRegistryUrl(),
             Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD));
@@ -104,7 +104,7 @@ public class RegistryMgmtAPITest extends TestBase {
         assertEquals(artifactMetaData.getName(), "Greeting");
     }
 
-    @Test(dependsOnMethods = "testCreateRegistry", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateRegistry")
     public void testListRegistries() throws ApiGenericException {
 
         // List registries
@@ -117,7 +117,7 @@ public class RegistryMgmtAPITest extends TestBase {
         assertTrue(found, message("{} not found in registries list: {}", SERVICE_REGISTRY_NAME, Json.encode(registries)));
     }
 
-    @Test(dependsOnMethods = "testCreateRegistry", timeOut = DEFAULT_TIMEOUT)
+    @Test(dependsOnMethods = "testCreateRegistry")
     public void testSearchRegistry() throws ApiGenericException {
 
         // Search registry by name
@@ -129,7 +129,7 @@ public class RegistryMgmtAPITest extends TestBase {
         assertEquals(registries.getItems().get(0).getName(), SERVICE_REGISTRY_NAME);
     }
 
-    @Test(dependsOnMethods = "testCreateRegistry", timeOut = DEFAULT_TIMEOUT, enabled = false)
+    @Test(dependsOnMethods = "testCreateRegistry", enabled = false)
     public void testFailToCreateRegistryIfItAlreadyExist() {
         // TODO: Enable after https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/issues/75
 
@@ -139,7 +139,7 @@ public class RegistryMgmtAPITest extends TestBase {
         assertThrows(() -> registryMgmtApi.createRegistry(registryCreateRest));
     }
 
-    @Test(timeOut = DEFAULT_TIMEOUT, priority = 1, dependsOnMethods = "testCreateRegistry")
+    @Test(priority = 1, dependsOnMethods = "testCreateRegistry")
     public void testDeleteRegistry() throws Throwable {
 
         LOGGER.info("delete registry '{}'", registry.getId());
@@ -149,7 +149,7 @@ public class RegistryMgmtAPITest extends TestBase {
         RegistryMgmtApiUtils.waitUntilRegistryIsDeleted(registryMgmtApi, registry.getId());
     }
 
-    @Test(priority = 2, timeOut = DEFAULT_TIMEOUT)
+    @Test(priority = 2)
     public void testDeleteProvisioningRegistry() throws Throwable {
 
         var registryCreateRest = new RegistryCreateRest()


### PR DESCRIPTION
The methods annotated with a timeOut are executed on a separate Thread which is a problem for ReportPortal