### PR TITLE
chore: make default region where Kafka is provisioned configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Environment variables can also be configured in the [config.json](#config-file) 
 | LAUNCH_KEY                  | A string key used to identify the current configuration and owner which is used to generate unique name and identify the launch            | change-me |
 | SKIP_TEARDOWN               | Skip the whole test teardown in most tests, although some of them will need top re-enable it to succeed                                    | false |
 | SKIP_KAFKA_TEARDOWN         | Skip only the Kafka instance cleanup teardown in the tests that don't require a new instance for each run to speed the local development   | false |
+| DEFAULT_KAFKA_REGION        | Change the default region where kafka instances will be provisioned if the test suite doesn't decide otherwise                             | us-east-1 |
 
 ## Config File
 

--- a/src/main/java/io/managed/services/test/Environment.java
+++ b/src/main/java/io/managed/services/test/Environment.java
@@ -71,6 +71,7 @@ public class Environment {
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
 
     private static final String SKIP_KAFKA_TEARDOWN_ENV = "SKIP_KAFKA_TEARDOWN";
+    private static final String DEFAULT_KAFKA_REGION_ENV = "DEFAULT_KAFKA_REGION";
 
     private static final String PROMETHEUS_PUSH_GATEWAY_ENV = "PROMETHEUS_PUSH_GATEWAY";
 
@@ -129,6 +130,9 @@ public class Environment {
 
     // Skip only the Kafka instance delete teardown to speed the local development
     public static final boolean SKIP_KAFKA_TEARDOWN = getOrDefault(SKIP_KAFKA_TEARDOWN_ENV, Boolean::parseBoolean, false);
+
+    // Change the default region where kafka instances will be provisioned if the test suite doesn't decide otherwise
+    public static final String DEFAULT_KAFKA_REGION = getOrDefault(DEFAULT_KAFKA_REGION_ENV, "us-east-1");
 
     public static final String PROMETHEUS_PUSH_GATEWAY = getOrDefault(PROMETHEUS_PUSH_GATEWAY_ENV, null);
 

--- a/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtApiUtils.java
@@ -64,7 +64,7 @@ public class KafkaMgmtApiUtils {
             .name(name)
             .multiAz(true)
             .cloudProvider("aws")
-            .region("us-east-1");
+            .region(Environment.DEFAULT_KAFKA_REGION);
 
         return applyKafkaInstance(api, payload);
     }

--- a/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
@@ -115,7 +115,7 @@ public class KafkaMgmtAPITest extends TestBase {
             .name(KAFKA_INSTANCE_NAME)
             .multiAz(true)
             .cloudProvider("aws")
-            .region("us-east-1");
+            .region(Environment.DEFAULT_KAFKA_REGION);
 
         log.info("create kafka instance '{}'", payload.getName());
         var k = KafkaMgmtApiUtils.createKafkaInstance(kafkaMgmtApi, payload);
@@ -275,7 +275,7 @@ public class KafkaMgmtAPITest extends TestBase {
             .name(KAFKA_INSTANCE_NAME)
             .multiAz(true)
             .cloudProvider("aws")
-            .region("us-east-1");
+            .region(Environment.DEFAULT_KAFKA_REGION);
 
         log.info("create kafka instance '{}' with existing name", payload.getName());
         assertThrows(ApiConflictException.class, () -> kafkaMgmtApi.createKafka(true, payload));
@@ -329,7 +329,7 @@ public class KafkaMgmtAPITest extends TestBase {
             .name(KAFKA2_INSTANCE_NAME)
             .multiAz(true)
             .cloudProvider("aws")
-            .region("us-east-1");
+            .region(Environment.DEFAULT_KAFKA_REGION);
 
         log.info("create kafka instance '{}'", KAFKA2_INSTANCE_NAME);
         var kafkaToDelete = KafkaMgmtApiUtils.createKafkaInstance(kafkaMgmtApi, payload);

--- a/src/test/java/io/managed/services/test/quickstarts/QuickstartsStepDefinitions.java
+++ b/src/test/java/io/managed/services/test/quickstarts/QuickstartsStepDefinitions.java
@@ -62,7 +62,7 @@ public class QuickstartsStepDefinitions {
             .name(KAFKA_INSTANCE_NAME)
             .multiAz(true)
             .cloudProvider("aws")
-            .region("us-east-1");
+            .region(Environment.DEFAULT_KAFKA_REGION);
 
         kafkaInstance = KafkaMgmtApiUtils.createKafkaInstance(kafkaMgmtApi, payload);
         LOGGER.debug(kafkaInstance);


### PR DESCRIPTION
**How to test it**
When running it locally add to the config.json the DEFAULT_KAFKA_REGION env:
```
{
   [...]
   "DEFAULT_KAFKA_REGION": "eu-west-1"
}
```
then execute the `KafkaMgmtAPITest`:
```
mvn verify -Dit.test=KafkaMgmtAPITest
```