### PR TITLE
Fix collectTopicMetric sum

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtMetricsUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtMetricsUtils.java
@@ -29,7 +29,7 @@ public class KafkaMgmtMetricsUtils {
     /**
      * Return the sum for all values of a single metric and topic
      *
-     * @param metricItems List<KafkaUserMetricItem>
+     * @param metricItems List<InstantQuery>
      * @param topicName   String
      * @param metric      String
      * @return double
@@ -38,11 +38,10 @@ public class KafkaMgmtMetricsUtils {
         Objects.requireNonNull(metricItems);
         return metricItems.stream()
             .filter(item -> item.getMetric() != null)
-            .filter(item -> item.getMetric().get("__name__") != null)
-            .filter(item -> item.getMetric().get("topic") != null)
-            .filter(item -> item.getMetric().get("__name__").equals(metric))
-            .filter(item -> item.getMetric().get("topic").equals(topicName))
-            .reduce((double) 0, (__, item) -> item.getValue(), Double::sum);
+            .filter(item -> metric.equals(item.getMetric().get("__name__")))
+            .filter(item -> topicName.equals(item.getMetric().get("topic")))
+            .mapToDouble(i -> i.getValue())
+            .sum();
     }
 
     public static void testMessageInTotalMetric(

--- a/src/test/java/io/managed/services/test/SmokeTest.java
+++ b/src/test/java/io/managed/services/test/SmokeTest.java
@@ -1,13 +1,18 @@
 package io.managed.services.test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openshift.cloud.api.kas.models.MetricsInstantQueryList;
 import io.managed.services.test.cli.CliGenericException;
 import io.managed.services.test.client.kafka.KafkaMessagingUtils;
+import io.managed.services.test.client.kafkamgmt.KafkaMgmtMetricsUtils;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -99,5 +104,17 @@ public class SmokeTest extends TestBase {
             "\n" +
             "{\"code\":404,\"error_message\":\"This server does not host this topic-partition.\",\"class\":\"UnknownTopicOrPartitionException\"}");
         assertEquals(404, code);
+    }
+
+    @Test
+    public void testCollectTopicMetric() throws IOException {
+        var stream = SmokeTest.class.getClassLoader().getResourceAsStream("smoke/user-metrics.json");
+        var metrics = new ObjectMapper().readValue(stream, MetricsInstantQueryList.class);
+
+        var result = KafkaMgmtMetricsUtils.collectTopicMetric(
+            metrics.getItems(),
+            "metric-test-topic",
+            "kafka_server_brokertopicmetrics_messages_in_total");
+        Assert.assertEquals(result, 2856);
     }
 }

--- a/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
+++ b/src/test/java/io/managed/services/test/kafka/LongLiveKafkaInstanceTest.java
@@ -146,7 +146,7 @@ public class LongLiveKafkaInstanceTest extends TestBase {
 
         var map = new HashMap<String, NewTopicInput>();
         map.put(TEST_TOPIC_NAME, topic.apply(TEST_TOPIC_NAME, 1));
-        map.put(METRIC_TOPIC_NAME, topic.apply(METRIC_TOPIC_NAME, 1));
+        map.put(METRIC_TOPIC_NAME, topic.apply(METRIC_TOPIC_NAME, 3));
         map.put(MULTI_PARTITION_TOPIC_NAME, topic.apply(MULTI_PARTITION_TOPIC_NAME, 3));
         return map;
     }

--- a/src/test/resources/smoke/user-metrics.json
+++ b/src/test/resources/smoke/user-metrics.json
@@ -1,0 +1,546 @@
+{
+  "kind": "MetricsInstantQueryList",
+  "id": "c55i81v6q598ar2lke00",
+  "items": [
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_used_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-2"
+      },
+      "timestamp": 1634217721769,
+      "value": 1089081344
+    },
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_used_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-1"
+      },
+      "timestamp": 1634217721769,
+      "value": 1088937984
+    },
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_used_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-0"
+      },
+      "timestamp": 1634217721769,
+      "value": 1089118208
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_softlimitbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721829,
+      "value": 357913941332
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_softlimitbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721829,
+      "value": 357913941332
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_softlimitbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721829,
+      "value": 357913941332
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721838,
+      "value": 31
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721838,
+      "value": 125859
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 1920
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 115188
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721838,
+      "value": 379374
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721838,
+      "value": 125788
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 936
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 114303
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "test-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 1670
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721838,
+      "value": 840
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721838,
+      "value": 125726
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_messages_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721838,
+      "value": 114573
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721848,
+      "value": 19256580
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 128652
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 299014244
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721848,
+      "value": 19245717
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 63561
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 295926365
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "test-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 38255
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721848,
+      "value": 19236384
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_out_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721848,
+      "value": 297250580
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_global_partition_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721857,
+      "value": 60
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_global_partition_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721857,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_global_partition_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721857,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kafka_topic:kafka_log_log_size:sum",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721869,
+      "value": 15960338
+    },
+    {
+      "metric": {
+        "__name__": "kafka_topic:kafka_log_log_size:sum",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721869,
+      "value": 190971999
+    },
+    {
+      "metric": {
+        "__name__": "kafka_topic:kafka_log_log_size:sum",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721869,
+      "value": 565695
+    },
+    {
+      "metric": {
+        "__name__": "kafka_topic:kafka_log_log_size:sum",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721869,
+      "value": 2838982398
+    },
+    {
+      "metric": {
+        "__name__": "kafka_topic:kafka_log_log_size:sum",
+        "topic": "test-topic"
+      },
+      "timestamp": 1634217721869,
+      "value": 122259
+    },
+    {
+      "metric": {
+        "__name__": "kafka_namespace:haproxy_server_bytes_in_total:rate5m"
+      },
+      "timestamp": 1634217721879,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kafka_namespace:haproxy_server_bytes_out_total:rate5m"
+      },
+      "timestamp": 1634217721890,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_available_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-2"
+      },
+      "timestamp": 1634217721900,
+      "value": 389926612992
+    },
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_available_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-1"
+      },
+      "timestamp": 1634217721900,
+      "value": 389926756352
+    },
+    {
+      "metric": {
+        "__name__": "kubelet_volume_stats_available_bytes",
+        "persistentvolumeclaim": "data-0-mk-e2e-ll-ci-stage-kafka-0"
+      },
+      "timestamp": 1634217721900,
+      "value": 389926576128
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_totalstorageusedbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721908,
+      "value": 1105915904
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_totalstorageusedbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721908,
+      "value": 1105731584
+    },
+    {
+      "metric": {
+        "__name__": "kafka_broker_quota_totalstorageusedbytes",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721908,
+      "value": 1105879040
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721917,
+      "value": 3355
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721917,
+      "value": 19256427
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 128652
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 297664643
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721917,
+      "value": 38089483
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721917,
+      "value": 19245717
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "metric-test-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 63561
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 294686259
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "test-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 38255
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__consumer_offsets"
+      },
+      "timestamp": 1634217721917,
+      "value": 250124
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "__strimzi_canary"
+      },
+      "timestamp": 1634217721917,
+      "value": 19236078
+    },
+    {
+      "metric": {
+        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage",
+        "topic": "multi-partitions-topic"
+      },
+      "timestamp": 1634217721917,
+      "value": 296028477
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_offline_partitions_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-0",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721931,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_offline_partitions_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-1",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721931,
+      "value": 0
+    },
+    {
+      "metric": {
+        "__name__": "kafka_controller_kafkacontroller_offline_partitions_count",
+        "statefulset_kubernetes_io_pod_name": "mk-e2e-ll-ci-stage-kafka-2",
+        "strimzi_io_cluster": "mk-e2e-ll-ci-stage"
+      },
+      "timestamp": 1634217721931,
+      "value": 0
+    }
+  ]
+}


### PR DESCRIPTION
The LongLiveKafkaInstanceTest.testMessageInTotalMetric is failing because it uses a multi partitions topic and the tested metric should be the sum of the metrics of each partition but the collectTopicMetric didn't sum them but just return the last one.

This small change fixes the collectTopicMetric function and is verified in the new smoke test `testCollectTopicMetric` 