### PR TITLE
Randomise test region when executing via Jenkins

### DIFF
--- a/src/main/java/io/managed/services/test/Environment.java
+++ b/src/main/java/io/managed/services/test/Environment.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Function;
 
 /**
@@ -210,6 +209,10 @@ public class Environment {
      * @return an aws region
      */
     public static String getKafkaAwsRegion() {
-        return (BUILD_NUMBER == null) ? REGIONS[0] : REGIONS[new Random().nextInt(REGIONS.length)];
+        if (BUILD_NUMBER == null) {
+            return REGIONS[0];
+        } else {
+            return (Integer.parseInt(BUILD_NUMBER) % 2 == 0) ? REGIONS[0] : REGIONS[1];
+        }
     }
 }


### PR DESCRIPTION
### Description
[MGDSTRM-5231](https://issues.redhat.com/browse/MGDSTRM-5231)

If the tests are running via Jenkins, a random region is chosen from the list (`us-east-1` or `eu-west-1`).

An alternative way to do this is to use the Jenkins `BUILD_NUMBER` on each test run and use ever/odd numbers to choose a region, though this might become cumbersome if more regions are added over time.

### Verification
- Set the `BUILD_NUMBER` ENV VAR to a value, either via a local ENV VAR or in the `config.json` file. This simulates the tests being executed via Jenkins
- Run the tests a couple of times and ensure both regions are being used
