### PR TITLE
kafka management api permission:

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
@@ -196,7 +196,7 @@ public class KafkaInstanceApiUtils {
             log.debug(topic);
             return topic;
         } else {
-            log.info("create kafka instance '{}'", payload.getName());
+            log.info("create topic '{}'", payload.getName());
             var topic = api.createTopic(payload);
             log.debug(topic);
             return topic;

--- a/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPIPermissionsTest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPIPermissionsTest.java
@@ -315,7 +315,7 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
     }
 
     @SneakyThrows
-    @Test
+    @Test (priority = 2)
     public void testAdminUserCanChangeTheKafkaInstanceOwner() {
 
         var authorizationTopicName = "authorization-topic-name";
@@ -331,7 +331,9 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
         );
 
         LOGGER.info("change of owner of instance");
-        KafkaMgmtApiUtils.changeKafkaInstanceOwner(mainAPI.kafkaMgmt(), kafka, Environment.SECONDARY_USERNAME, Environment.SECONDARY_PASSWORD);
+        KafkaMgmtApiUtils.changeKafkaInstanceOwner(adminAPI.kafkaMgmt(), kafka, Environment.SECONDARY_USERNAME);
+        // wait until owner is changed (waiting for Rollout on Brokers)
+        KafkaMgmtApiUtils.waitUntilOwnerIsChanged(kafkaInstanceAPISecondaryUser);
 
         // try to perform operation (i.e., delete topic) without Authorization exception
         LOGGER.info("deletion of topic should now pass authorization phase");
@@ -339,13 +341,10 @@ public class KafkaMgmtAPIPermissionsTest extends TestBase {
                 ApiNotFoundException.class,
                 () -> kafkaInstanceAPISecondaryUser.deleteTopic(authorizationTopicName)
         );
-
-        // owner is changed back to primary user in order for other test to run properly
-        KafkaMgmtApiUtils.changeKafkaInstanceOwner(secondaryAPI.kafkaMgmt(), kafka, Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
     }
 
     @SneakyThrows
-    @Test (priority = 2)
+    @Test (priority = 3)
     // test is should be executed as last one.
     public void testAdminUserCanDeleteTheKafkaInstance() {
         KafkaMgmtApiUtils.cleanKafkaInstance(adminAPI.kafkaMgmt(), KAFKA_INSTANCE_NAME);


### PR DESCRIPTION
1.  `change owner` test implemented. 
1. addition of "hack" (`waitUntilOwnerIsChanged`) as current implementation doesn't wait for rollback correctly. 