### PR TITLE
chore: add Kafka re-authentication test

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafka/KafkaAdmin.java
+++ b/src/main/java/io/managed/services/test/client/kafka/KafkaAdmin.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 
 public class KafkaAdmin implements AutoCloseable {
 
-    public final Admin admin;
+    private final Admin admin;
 
     public KafkaAdmin(String bootstrapHost, String clientID, String clientSecret) {
         this(bootstrapHost, KafkaAuthMethod.oAuthConfigs(bootstrapHost, clientID, clientSecret));
@@ -66,6 +66,14 @@ public class KafkaAdmin implements AutoCloseable {
         } catch (ExecutionException e) {
             throw e.getCause();
         }
+    }
+
+    public Admin getAdmin() {
+        return admin;
+    }
+
+    public String getClusterId() {
+        return get(admin.describeCluster().clusterId());
     }
 
     public void createTopic(String name) {

--- a/src/main/java/io/managed/services/test/client/kafka/KafkaAdminUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafka/KafkaAdminUtils.java
@@ -1,0 +1,134 @@
+package io.managed.services.test.client.kafka;
+
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.common.network.KafkaChannel;
+import org.apache.kafka.common.network.Selector;
+import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
+
+import java.util.HashMap;
+import java.util.Objects;
+
+public class KafkaAdminUtils {
+
+    static private <T> T assertType(Object o, Class<T> c) {
+        Objects.requireNonNull(o);
+        Objects.requireNonNull(c);
+
+        if (c.isInstance(o)) {
+            return c.cast(o);
+        } else {
+            throw new AssertionError(String.format("object of type '%s' can not be cast to '%s'", o.getClass().getName(), c.getName()));
+        }
+    }
+
+    static private KafkaAdminClient getKafkaAdminClient(KafkaAdmin admin) {
+        return assertType(admin.getAdmin(), KafkaAdminClient.class);
+    }
+
+    static private NetworkClient getKafkaNetworkClient(KafkaAdminClient kafkaAdminClient)
+        throws NoSuchFieldException, IllegalAccessException {
+
+        var clientField = KafkaAdminClient.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        var client = clientField.get(kafkaAdminClient);
+
+        return assertType(client, NetworkClient.class);
+    }
+
+    static private Selector getKafkaSelector(NetworkClient kafkaNetworkClient)
+        throws NoSuchFieldException, IllegalAccessException {
+
+        var selectorField = NetworkClient.class.getDeclaredField("selector");
+        selectorField.setAccessible(true);
+        var selector = selectorField.get(kafkaNetworkClient);
+
+        return assertType(selector, Selector.class);
+    }
+
+    static private KafkaChannel getAnyKafkaChannel(Selector kafkaSelector)
+        throws NoSuchFieldException, IllegalAccessException {
+
+        var channelsField = Selector.class.getDeclaredField("channels");
+        channelsField.setAccessible(true);
+        var channels = channelsField.get(kafkaSelector);
+
+        var kafkaChannels = assertType(channels, HashMap.class);
+
+        var channel = kafkaChannels.values().stream().findAny().orElseThrow();
+
+        return assertType(channel, KafkaChannel.class);
+    }
+
+    static private SaslClientAuthenticator getKafkaSaslClientAuthenticator(KafkaChannel kafkaChannel)
+        throws NoSuchFieldException, IllegalAccessException {
+
+        var authenticatorField = KafkaChannel.class.getDeclaredField("authenticator");
+        authenticatorField.setAccessible(true);
+        var authenticator = authenticatorField.get(kafkaChannel);
+
+        return assertType(authenticator, SaslClientAuthenticator.class);
+    }
+
+    static private Long getPositiveSessionLifetimeMs(SaslClientAuthenticator kafkaAuthenticator)
+        throws NoSuchFieldException, IllegalAccessException {
+
+        var reauthInfoField = SaslClientAuthenticator.class.getDeclaredField("reauthInfo");
+        reauthInfoField.setAccessible(true);
+        var authenticator = reauthInfoField.get(kafkaAuthenticator);
+
+        Objects.requireNonNull(authenticator);
+
+        // SaslClientAuthenticator.ReauthInfo ins private so we will need to assume
+        // the reauthInfo field is of type ReauthInfo and retrieve the positiveSessionLifetimeMs
+
+        var positiveSessionLifetimeMsField = authenticator.getClass().getDeclaredField("positiveSessionLifetimeMs");
+        positiveSessionLifetimeMsField.setAccessible(true);
+        var positiveSessionLifetimeMs = positiveSessionLifetimeMsField.get(authenticator);
+
+        if (positiveSessionLifetimeMs == null) {
+            // if the reauthentication is disabled positiveSessionLifetimeMs is null
+            return null;
+        }
+
+        return assertType(positiveSessionLifetimeMs, Long.class);
+    }
+
+    @SneakyThrows
+    static public Long getPositiveSessionLifetimeMs(KafkaAdmin admin) {
+
+        // admin
+        var kafkaAdminClient = getKafkaAdminClient(admin);
+
+        // admin.client
+        var kafkaNetworkClient = getKafkaNetworkClient(kafkaAdminClient);
+
+        // admin.client.selector
+        var kafkaSelector = getKafkaSelector(kafkaNetworkClient);
+
+        // admin.client.selector.channels[any]
+        var kafkaChannel = getAnyKafkaChannel(kafkaSelector);
+
+        // admin.client.selector.channels[any].authenticator
+        var kafkaAuthenticator = getKafkaSaslClientAuthenticator(kafkaChannel);
+
+        // admin.client.selector.channels[any].authenticator.reauthInfo.positiveSessionLifetimeMs
+        return getPositiveSessionLifetimeMs(kafkaAuthenticator);
+    }
+
+    static public Long getAuthenticatorPositiveSessionLifetimeMs(
+        String bootstrapHost,
+        String clientID,
+        String clientSecret) {
+
+        var admin = new KafkaAdmin(bootstrapHost, clientID, clientSecret);
+
+        // initialize the Kafka Admin by making any requests
+        admin.getClusterId();
+
+        return getPositiveSessionLifetimeMs(admin);
+    }
+}
+
+

--- a/src/test/java/io/managed/services/test/kafka/KafkaRegressionTest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaRegressionTest.java
@@ -1,0 +1,71 @@
+package io.managed.services.test.kafka;
+
+import com.openshift.cloud.api.kas.models.KafkaRequestPayload;
+import io.managed.services.test.Environment;
+import io.managed.services.test.client.ApplicationServicesApi;
+import io.managed.services.test.client.kafkamgmt.KafkaMgmtApi;
+import io.managed.services.test.client.kafkamgmt.KafkaMgmtApiUtils;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.managed.services.test.TestUtils.assumeTeardown;
+import static java.time.Duration.ofSeconds;
+import static org.testng.Assert.assertNotNull;
+
+@Log4j2
+public class KafkaRegressionTest {
+    static final String KAFKA_INSTANCE_NAME = "mk-e2e-reg-" + Environment.LAUNCH_KEY;
+
+    private KafkaMgmtApi kafkaMgmtApi;
+
+    @BeforeClass
+    public void bootstrap() {
+        assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
+        assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
+
+        var apps = ApplicationServicesApi.applicationServicesApi(
+            Environment.PRIMARY_USERNAME,
+            Environment.PRIMARY_PASSWORD);
+
+        kafkaMgmtApi = apps.kafkaMgmt();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown() {
+        assumeTeardown();
+
+        try {
+            KafkaMgmtApiUtils.cleanKafkaInstance(kafkaMgmtApi, KAFKA_INSTANCE_NAME);
+        } catch (Throwable t) {
+            log.error("clean second kafka instance error: ", t);
+        }
+    }
+
+    @Test(priority = 2)
+    @SneakyThrows
+    public void testDeleteProvisioningKafkaInstance() {
+
+        // Create Kafka Instance
+        var payload = new KafkaRequestPayload()
+            .name(KAFKA_INSTANCE_NAME)
+            .multiAz(true)
+            .cloudProvider("aws")
+            .region(Environment.DEFAULT_KAFKA_REGION);
+
+        log.info("create kafka instance '{}'", KAFKA_INSTANCE_NAME);
+        var kafkaToDelete = KafkaMgmtApiUtils.createKafkaInstance(kafkaMgmtApi, payload);
+        log.debug(kafkaToDelete);
+
+        log.info("wait 3 seconds before start deleting");
+        Thread.sleep(ofSeconds(3).toMillis());
+
+        log.info("delete kafka '{}'", kafkaToDelete.getId());
+        kafkaMgmtApi.deleteKafkaById(kafkaToDelete.getId(), true);
+
+        log.info("wait for kafka to be deleted '{}'", kafkaToDelete.getId());
+        KafkaMgmtApiUtils.waitUntilKafkaIsDeleted(kafkaMgmtApi, kafkaToDelete.getId());
+    }
+}


### PR DESCRIPTION
What:
- Add a re-auth test that verifies that after disabling the re-authentication option the token lifetime is null
- Make the  [KafkaMgmtAPITest.java](https://github.com/bf2fc6cc711aee1a0c2a/e2e-test-suite/compare/reauth?expand=1#diff-fc0ebafd94aae17bf1c9e2f607fd06f6ee2c64b71a4eaf1c709b31a53297ffe0) easier to debug locally