### PR TITLE
renovate, complete update to new tokens

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '*/7 8-18 * * 1-5' # Every hour, between 08:00 and 18:00, Monday through Friday
+    - cron: '0 8-18 * * 1-5' # Every hour, between 08:00 and 18:00, Monday through Friday
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -206,11 +206,6 @@
             <artifactId>scribejava-apis</artifactId>
             <version>8.3.1</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.3.1</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/io/managed/services/test/SmokeTest.java
+++ b/src/test/java/io/managed/services/test/SmokeTest.java
@@ -1,7 +1,6 @@
 package io.managed.services.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
 import com.openshift.cloud.api.kas.models.MetricsInstantQueryList;
 import io.managed.services.test.cli.CliGenericException;
 import io.managed.services.test.client.kafka.KafkaMessagingUtils;
@@ -24,11 +23,6 @@ import static org.testng.Assert.assertTrue;
 
 public class SmokeTest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(SmokeTest.class);
-
-    @Test
-    public void renovate() {
-        Gson gson = new Gson();
-    }
 
     @Test
     public void random() {


### PR DESCRIPTION
changed interval to less frequent period (1 hour)
keeping new token, 
removal of test which served to initiate Renovate action by using old version of gson lib. 