### PR TITLE
fix of number of brokers to check, i.e., from 3 to 1 in case of developer kafka

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkamgmt/KafkaMgmtApiUtils.java
@@ -288,6 +288,11 @@ public class KafkaMgmtApiUtils {
         var admin = "admin-server-" + bootstrap;
         var hosts = new ArrayList<>(List.of(bootstrap, admin, broker0, broker1, broker2));
 
+        // if Kafka instance is of type developer it is smaller and does not have broker1 and broker 2
+        if (Objects.requireNonNull(kafka.getInstanceType()).equals("developer")) {
+            hosts.removeAll(List.of(broker1, broker2));
+        }
+
         ThrowingFunction<Boolean, Boolean, java.lang.Error> ready = last -> {
 
             for (var i = 0; i < hosts.size(); i++) {


### PR DESCRIPTION
New type of kafka instances (i.e., `developer`) provides only one worker broker, => lookup of 3 expected brokers would end up in failure. 