### PR TITLE
Partition limit

### DIFF
--- a/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApi.java
+++ b/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApi.java
@@ -20,6 +20,7 @@ import com.openshift.cloud.api.kas.auth.models.NewTopicInput;
 import com.openshift.cloud.api.kas.auth.models.SortDirection;
 import com.openshift.cloud.api.kas.auth.models.Topic;
 import com.openshift.cloud.api.kas.auth.models.TopicOrderKey;
+import com.openshift.cloud.api.kas.auth.models.TopicSettings;
 import com.openshift.cloud.api.kas.auth.models.TopicsList;
 import io.managed.services.test.client.BaseApi;
 import io.managed.services.test.client.exception.ApiGenericException;
@@ -53,6 +54,12 @@ public class KafkaInstanceApi extends BaseApi {
     @Override
     protected void setAccessToken(String t) {
         apiClient.setAccessToken(t);
+    }
+
+
+    public Topic updateTopic(String name, TopicSettings ts) throws ApiGenericException {
+        //return getTopics(null, null, null, null, null);
+        return retry(() -> topicsApi.updateTopic(name, ts));
     }
 
     public TopicsList getTopics() throws ApiGenericException {

--- a/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
@@ -204,6 +204,7 @@ public class KafkaInstanceApiUtils {
         return api.updateTopic(name, topicSettings);
     }
 
+    // only partitions from public topic are visible (internal and redhat topic are not included, e.g. __consumer_offsets, __redhat_* )
     public static int getPartitionCountTotal(KafkaInstanceApi api) throws ApiGenericException {
         return api.getTopics().getItems().stream().mapToInt(t -> Objects.requireNonNull(t.getPartitions()).size()).reduce(0, Integer::sum);
     }

--- a/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
@@ -28,6 +28,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.ws.rs.client.ClientBuilder;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -200,7 +201,10 @@ public class KafkaInstanceApiUtils {
     public static Topic updateTopicPartition(KafkaInstanceApi api, String name, int partitions) throws ApiGenericException {
         TopicSettings topicSettings = new TopicSettings();
         topicSettings.setNumPartitions(partitions);
-        return api.updateTopic(name,topicSettings);
+        return api.updateTopic(name, topicSettings);
     }
 
+    public static int getPartitionCountTotal(KafkaInstanceApi api) throws ApiGenericException {
+        return api.getTopics().getItems().stream().mapToInt(t -> Objects.requireNonNull(t.getPartitions()).size()).reduce(0, Integer::sum);
+    }
 }

--- a/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
+++ b/src/main/java/io/managed/services/test/client/kafkainstance/KafkaInstanceApiUtils.java
@@ -197,4 +197,10 @@ public class KafkaInstanceApiUtils {
         }
     }
 
+    public static Topic updateTopicPartition(KafkaInstanceApi api, String name, int partitions) throws ApiGenericException {
+        TopicSettings topicSettings = new TopicSettings();
+        topicSettings.setNumPartitions(partitions);
+        return api.updateTopic(name,topicSettings);
+    }
+
 }

--- a/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
@@ -8,7 +8,6 @@ import io.managed.services.test.TestBase;
 import io.managed.services.test.TestUtils;
 import io.managed.services.test.client.ApplicationServicesApi;
 import io.managed.services.test.client.exception.ApiConflictException;
-import io.managed.services.test.client.exception.ApiGenericException;
 import io.managed.services.test.client.exception.ApiLockedException;
 import io.managed.services.test.client.exception.ApiNotFoundException;
 import io.managed.services.test.client.exception.ApiUnauthorizedException;
@@ -154,67 +153,6 @@ public class KafkaInstanceAPITest extends TestBase {
             .settings(new TopicSettings().numPartitions(1));
         var topic = kafkaInstanceApi.createTopic(payload);
         LOGGER.debug(topic);
-    }
-
-    @Test
-    @SneakyThrows
-    public void testCreateTopicPartition() {
-        // getting test-topic should fail because the topic shouldn't exist
-        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
-        LOGGER.info("create topic '{}', with too many partitions", "topic-1001");
-        var payload = new NewTopicInput()
-                .name("topic-1001")
-                .settings(new TopicSettings().numPartitions(1001));
-        assertThrows(ApiGenericException.class,
-                () -> kafkaInstanceApi.createTopic(payload));
-    }
-
-    @Test
-    @SneakyThrows
-    public void testOverflowPartitionsLimitOnInstance() {
-        // getting test-topic should fail because the topic shouldn't exist
-        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
-        //LOGGER.info("create topic '{}', with too many partitions", "topic-1001");
-        //var payload = new NewTopicInput()
-        //        .name("topic-1001")
-        //        .settings(new TopicSettings().numPartitions(1001));
-        //assertThrows(ApiGenericException.class,
-        //        () -> kafkaInstanceApi.createTopic(payload));
-        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
-        var payload = new NewTopicInput()
-                .name("a-300")
-                .settings(new TopicSettings().numPartitions(800));
-        var topic = kafkaInstanceApi.createTopic(payload);
-        LOGGER.debug(topic);
-
-        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
-        var payload2 = new NewTopicInput()
-                .name("b-300")
-                .settings(new TopicSettings().numPartitions(800));
-        var topic2 = kafkaInstanceApi.createTopic(payload2);
-        LOGGER.debug(topic2);
-
-        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
-        var payload3 = new NewTopicInput()
-                .name("c-401")
-                .settings(new TopicSettings().numPartitions(401));
-        var topic3 = kafkaInstanceApi.createTopic(payload3);
-        LOGGER.debug(topic3);
-    }
-
-    @Test
-    @SneakyThrows
-    // TODO
-    public void testIncreaseNumberOfTopicsPartitions() {
-        // getting test-topic should fail because the topic shouldn't exist
-        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
-        LOGGER.info("create topic '{}', with too many partitions", "topic-1005");
-        var payload = new NewTopicInput()
-                .name("topic-good")
-                .settings(new TopicSettings().numPartitions(2));
-        kafkaInstanceApi.createTopic(payload);
-        assertThrows(ApiGenericException.class,
-                () -> KafkaInstanceApiUtils.updateTopicPartition(kafkaInstanceApi, "topic-good",1005));
     }
 
     @Test(dependsOnMethods = "testCreateTopic")

--- a/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaInstanceAPITest.java
@@ -8,6 +8,7 @@ import io.managed.services.test.TestBase;
 import io.managed.services.test.TestUtils;
 import io.managed.services.test.client.ApplicationServicesApi;
 import io.managed.services.test.client.exception.ApiConflictException;
+import io.managed.services.test.client.exception.ApiGenericException;
 import io.managed.services.test.client.exception.ApiLockedException;
 import io.managed.services.test.client.exception.ApiNotFoundException;
 import io.managed.services.test.client.exception.ApiUnauthorizedException;
@@ -153,6 +154,67 @@ public class KafkaInstanceAPITest extends TestBase {
             .settings(new TopicSettings().numPartitions(1));
         var topic = kafkaInstanceApi.createTopic(payload);
         LOGGER.debug(topic);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testCreateTopicPartition() {
+        // getting test-topic should fail because the topic shouldn't exist
+        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
+        LOGGER.info("create topic '{}', with too many partitions", "topic-1001");
+        var payload = new NewTopicInput()
+                .name("topic-1001")
+                .settings(new TopicSettings().numPartitions(1001));
+        assertThrows(ApiGenericException.class,
+                () -> kafkaInstanceApi.createTopic(payload));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testOverflowPartitionsLimitOnInstance() {
+        // getting test-topic should fail because the topic shouldn't exist
+        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
+        //LOGGER.info("create topic '{}', with too many partitions", "topic-1001");
+        //var payload = new NewTopicInput()
+        //        .name("topic-1001")
+        //        .settings(new TopicSettings().numPartitions(1001));
+        //assertThrows(ApiGenericException.class,
+        //        () -> kafkaInstanceApi.createTopic(payload));
+        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
+        var payload = new NewTopicInput()
+                .name("a-300")
+                .settings(new TopicSettings().numPartitions(800));
+        var topic = kafkaInstanceApi.createTopic(payload);
+        LOGGER.debug(topic);
+
+        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
+        var payload2 = new NewTopicInput()
+                .name("b-300")
+                .settings(new TopicSettings().numPartitions(800));
+        var topic2 = kafkaInstanceApi.createTopic(payload2);
+        LOGGER.debug(topic2);
+
+        LOGGER.info("create topic '{}'", TEST_TOPIC_NAME);
+        var payload3 = new NewTopicInput()
+                .name("c-401")
+                .settings(new TopicSettings().numPartitions(401));
+        var topic3 = kafkaInstanceApi.createTopic(payload3);
+        LOGGER.debug(topic3);
+    }
+
+    @Test
+    @SneakyThrows
+    // TODO
+    public void testIncreaseNumberOfTopicsPartitions() {
+        // getting test-topic should fail because the topic shouldn't exist
+        //assertThrows(ApiNotFoundException.class, () -> kafkaInstanceApi.getTopic(TEST_TOPIC_NAME));
+        LOGGER.info("create topic '{}', with too many partitions", "topic-1005");
+        var payload = new NewTopicInput()
+                .name("topic-good")
+                .settings(new TopicSettings().numPartitions(2));
+        kafkaInstanceApi.createTopic(payload);
+        assertThrows(ApiGenericException.class,
+                () -> KafkaInstanceApiUtils.updateTopicPartition(kafkaInstanceApi, "topic-good",1005));
     }
 
     @Test(dependsOnMethods = "testCreateTopic")


### PR DESCRIPTION
addition of test to check enforced partition limit for both creation and configuration of topics by making sure there is no possibility of breaching partition limit (either within single topic or in sum of all public topic's partitions in given instance) after at most 15 seconds.

**Brief explanation**

The test may be later refactored to either try to manipulate limits and wait for failure, or be ordered, But I did not see the point in it as penalty for it is in sum 30 seconds total. 

I also pushed **reauthentication** to be executed as the last, prior only to the deletion itself, as it always caused some of brokers being down what makes it impossible for creating topic with given replication factor 3 to being created what would cause additional waiting. 
