### PR TITLE
addition of all *.config.env files to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 *.config.json
 config.json
 test-output/
-.env
+*.config.env
+


### PR DESCRIPTION
add `.*config.env` into gitignore in addition to `.*config.json`, as it is more useful format when passing envs to container for local debuging. 