### PR TITLE
quarkus app: changed route, login to cli, and vertx client

### DIFF
--- a/src/main/java/io/managed/services/test/cli/CLIUtils.java
+++ b/src/main/java/io/managed/services/test/cli/CLIUtils.java
@@ -85,13 +85,17 @@ public class CLIUtils {
     }
 
     public static CompletableFuture<Void> login(Vertx vertx, CLI cli, KeycloakLoginSession session) {
+        boolean insecure = Environment.KAFKA_INSECURE_TLS;
+        return login(vertx, cli, session, insecure);
+    }
+
+    public static CompletableFuture<Void> login(Vertx vertx, CLI cli, KeycloakLoginSession session, boolean insecureLogin) {
 
         var authURL = String.format("%s/auth/realms/%s", Environment.REDHAT_SSO_URI, Environment.REDHAT_SSO_REALM);
         var masAuthURL = String.format("%s/auth/realms/%s", Environment.OPENSHIFT_IDENTITY_URI, Environment.OPENSHIFT_IDENTITY_REALM);
-        boolean insecure = Environment.KAFKA_INSECURE_TLS;
 
         LOGGER.info("start CLI login with username: {}", session.getUsername());
-        var process = cli.login(Environment.OPENSHIFT_API_URI, authURL, masAuthURL, insecure);
+        var process = cli.login(Environment.OPENSHIFT_API_URI, authURL, masAuthURL, insecureLogin);
 
         LOGGER.info("start oauth login against CLI");
         var oauthFuture = parseUrl(vertx, process.stdout(), String.format("%s/auth/.*", Environment.REDHAT_SSO_URI))
@@ -198,7 +202,7 @@ public class CLIUtils {
     public static Config kubeConfig(String server, String token, String namespace) {
         var cluster = new Cluster();
         cluster.setServer(server);
-
+        cluster.setInsecureSkipTlsVerify(true);
         var namedCluster = new NamedCluster();
         namedCluster.setCluster(cluster);
         namedCluster.setName("default");

--- a/src/test/java/io/managed/services/test/quickstarts/QuarkusApplicationTest.java
+++ b/src/test/java/io/managed/services/test/quickstarts/QuarkusApplicationTest.java
@@ -135,7 +135,8 @@ public class QuarkusApplicationTest extends TestBase {
 
         LOGGER.info("login the cli");
         cli = new CLI(cliBinary);
-        CLIUtils.login(vertx, cli, auth).get();
+        // insecure login
+        CLIUtils.login(vertx, cli, auth, false).get();
 
         // User
         LOGGER.info("authenticate user '{}' against RH SSO", auth.getUsername());
@@ -481,7 +482,7 @@ public class QuarkusApplicationTest extends TestBase {
     @Test(dependsOnMethods = "testCreateServiceBinding")
     public void testQuarkusApplication() throws Throwable {
 
-        var endpoint = String.format("https://%s", route.getSpec().getHost());
+        var endpoint = String.format("http://%s", route.getSpec().getHost());
         var client = new QuarkusSample(vertx, endpoint);
 
         LOGGER.info("start streaming prices from: {}", endpoint);

--- a/src/test/resources/quarkus/rhoas-kafka-quickstart-example.yml
+++ b/src/test/resources/quarkus/rhoas-kafka-quickstart-example.yml
@@ -71,5 +71,3 @@ spec:
     name: rhoas-kafka-quickstart-example
   port:
     targetPort: http
-  tls:
-    termination: edge


### PR DESCRIPTION
Quarkus app runs now against custom cluster,
cli logs with --insecure flag
vertx client skips tls verification
route for quickstarts allows plain comunication, and client targets http endpoint (insted of https)