### PR TITLE
Set offset to fix sort order from CLI

### DIFF
--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -252,7 +252,7 @@ public class KafkaCLITest extends TestBase {
     @SneakyThrows
     public void testConsumeMessages() {
         LOGGER.info("consuming all messages from partition '0' topic '{}'", TOPIC_NAME_PRODUCE_CONSUME);
-        List<Record> consumedRecords = cli.consumeRecords(TOPIC_NAME_PRODUCE_CONSUME, kafka.getId(), 0);
+        List<Record> consumedRecords = cli.consumeRecords(TOPIC_NAME_PRODUCE_CONSUME, kafka.getId(), 0, 0);
 
         int i = 0;
         for (Record consumedRecord: consumedRecords) {


### PR DESCRIPTION
v0.12.z of the kafka-admin-api has changed the sort order of records from this endpoint if neither offset nor timestamp are specified (change required by the UI). This breaks a test here, so setting the offset appropriately to fix.