### PR TITLE
cli: migration from usage of kafka sdk to service-account sdk for ser…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
             <version>0.24.0</version>
         </dependency>
         <dependency>
+            <groupId>com.redhat.cloud</groupId>
+            <artifactId>service-accounts-sdk</artifactId>
+            <version>0.27.1</version>
+        </dependency>
+        <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-client</artifactId>
             <version>2.2.5.Final</version>

--- a/src/main/java/io/managed/services/test/cli/CLI.java
+++ b/src/main/java/io/managed/services/test/cli/CLI.java
@@ -11,8 +11,7 @@ import com.openshift.cloud.api.kas.auth.models.Topic;
 import com.openshift.cloud.api.kas.auth.models.TopicsList;
 import com.openshift.cloud.api.kas.models.KafkaRequest;
 import com.openshift.cloud.api.kas.models.KafkaRequestList;
-import com.openshift.cloud.api.kas.models.ServiceAccount;
-import com.openshift.cloud.api.kas.models.ServiceAccountList;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import com.openshift.cloud.api.srs.models.Registry;
 import com.openshift.cloud.api.srs.models.RegistryList;
 import io.managed.services.test.Environment;
@@ -156,14 +155,14 @@ public class CLI {
         return p.asJson(KafkaRequestList.class);
     }
 
-    public ServiceAccount describeServiceAccount(String id) throws CliGenericException {
-        return retry(() -> exec("service-account", "describe", "--id", id))
-            .asJson(ServiceAccount.class);
+    public ServiceAccountData describeServiceAccount(String id) throws CliGenericException {
+        return retry(() -> exec("service-account", "describe", "--id", id, "--enable-auth-v2"))
+            .asJson(ServiceAccountData.class);
     }
 
-    public ServiceAccountList listServiceAccount() throws CliGenericException {
-        return retry(() -> exec("service-account", "list", "-o", "json"))
-            .asJson(ServiceAccountList.class);
+    public ServiceAccountData[] listServiceAccount() throws CliGenericException {
+        return retry(() -> exec("service-account", "list", "-o", "json", "--enable-auth-v2"))
+            .asJson(ServiceAccountData[].class);
     }
 
     public void deleteServiceAccount(String id) throws CliGenericException {

--- a/src/main/java/io/managed/services/test/cli/CLIUtils.java
+++ b/src/main/java/io/managed/services/test/cli/CLIUtils.java
@@ -3,7 +3,7 @@ package io.managed.services.test.cli;
 import com.openshift.cloud.api.kas.auth.models.ConsumerGroup;
 import com.openshift.cloud.api.kas.auth.models.Topic;
 import com.openshift.cloud.api.kas.models.KafkaRequest;
-import com.openshift.cloud.api.kas.models.ServiceAccountListItem;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import com.openshift.cloud.api.srs.models.Registry;
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.Cluster;
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -174,8 +175,8 @@ public class CLIUtils {
         });
     }
 
-    public static Optional<ServiceAccountListItem> getServiceAccountByName(CLI cli, String name) throws CliGenericException {
-        return cli.listServiceAccount().getItems().stream().filter(sa -> name.equals(sa.getName())).findAny();
+    public static Optional<ServiceAccountData> getServiceAccountByName(CLI cli, String name) throws CliGenericException {
+        return Arrays.stream(cli.listServiceAccount()).filter(sa -> name.equals(sa.getName())).findAny();
     }
 
     public static ServiceAccountSecret createServiceAccount(CLI cli, String name) throws CliGenericException {

--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -152,7 +152,7 @@ public class KafkaCLITest extends TestBase {
     public void testLogin() {
 
         LOGGER.info("verify that we aren't logged-in");
-        //assertThrows(CliGenericException.class, () -> cli.listKafka());
+        assertThrows(CliGenericException.class, () -> cli.listKafka());
 
         LOGGER.info("login the CLI");
         CLIUtils.login(vertx, cli, Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD).get();
@@ -183,7 +183,8 @@ public class KafkaCLITest extends TestBase {
     @SneakyThrows
     public void testDescribeServiceAccount() {
 
-        var sa = cli.describeServiceAccount(serviceAccount.getClientId());
+        LOGGER.info("describe service account by id field");
+        var sa = cli.describeServiceAccount(serviceAccount.getId());
         LOGGER.debug(sa);
 
         assertEquals(sa.getName(), SERVICE_ACCOUNT_NAME);
@@ -195,7 +196,6 @@ public class KafkaCLITest extends TestBase {
 
         LOGGER.info("create kafka instance with name {}", KAFKA_INSTANCE_NAME);
         var k = cli.createKafka(KAFKA_INSTANCE_NAME);
-        //var k = cli.describeKafka("ccu45rmjgec8hfhj1h3g");
         LOGGER.debug(k);
 
         LOGGER.info("wait for kafka instance: {}", k.getId());

--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -3,7 +3,7 @@ package io.managed.services.test.devexp;
 import com.openshift.cloud.api.kas.auth.models.Record;
 import com.openshift.cloud.api.kas.auth.models.Topic;
 import com.openshift.cloud.api.kas.models.KafkaRequest;
-import com.openshift.cloud.api.kas.models.ServiceAccountListItem;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import io.managed.services.test.Environment;
 import io.managed.services.test.TestBase;
 import io.managed.services.test.cli.CLI;
@@ -73,7 +73,7 @@ public class KafkaCLITest extends TestBase {
 
     private KafkaRequest kafka;
     private ServiceAccountSecret serviceAccountSecret;
-    private ServiceAccountListItem serviceAccount;
+    private ServiceAccountData serviceAccount;
     private Topic topic;
 
     private final List<String> records = List.of("First message", "Second message", "Third message");
@@ -152,7 +152,7 @@ public class KafkaCLITest extends TestBase {
     public void testLogin() {
 
         LOGGER.info("verify that we aren't logged-in");
-        assertThrows(CliGenericException.class, () -> cli.listKafka());
+        //assertThrows(CliGenericException.class, () -> cli.listKafka());
 
         LOGGER.info("login the CLI");
         CLIUtils.login(vertx, cli, Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD).get();
@@ -183,7 +183,7 @@ public class KafkaCLITest extends TestBase {
     @SneakyThrows
     public void testDescribeServiceAccount() {
 
-        var sa = cli.describeServiceAccount(serviceAccount.getId());
+        var sa = cli.describeServiceAccount(serviceAccount.getClientId());
         LOGGER.debug(sa);
 
         assertEquals(sa.getName(), SERVICE_ACCOUNT_NAME);
@@ -195,6 +195,7 @@ public class KafkaCLITest extends TestBase {
 
         LOGGER.info("create kafka instance with name {}", KAFKA_INSTANCE_NAME);
         var k = cli.createKafka(KAFKA_INSTANCE_NAME);
+        //var k = cli.describeKafka("ccu45rmjgec8hfhj1h3g");
         LOGGER.debug(k);
 
         LOGGER.info("wait for kafka instance: {}", k.getId());
@@ -496,11 +497,11 @@ public class KafkaCLITest extends TestBase {
     @SneakyThrows
     public void testDeleteServiceAccount() {
 
-        LOGGER.info("delete service account '{}'", serviceAccount.getId());
-        cli.deleteServiceAccount(serviceAccount.getId());
+        LOGGER.info("delete service account '{}'", serviceAccount.getClientId());
+        cli.deleteServiceAccount(serviceAccount.getClientId());
 
         assertThrows(CliNotFoundException.class,
-            () -> cli.describeServiceAccount(serviceAccount.getId()));
+            () -> cli.describeServiceAccount(serviceAccount.getClientId()));
     }
 
     @Test(dependsOnMethods = "testCreateKafkaInstance", priority = 3, enabled = true)


### PR DESCRIPTION
cli: usage of service-account-sdk instead of service-account. 
switch to the usage of `clientId` instead of `id` field when filtering specific service-account. 
  