### PR TITLE
cli: remove enable-auth-v2 flag

### DIFF
--- a/src/main/java/io/managed/services/test/cli/CLI.java
+++ b/src/main/java/io/managed/services/test/cli/CLI.java
@@ -156,12 +156,12 @@ public class CLI {
     }
 
     public ServiceAccountData describeServiceAccount(String id) throws CliGenericException {
-        return retry(() -> exec("service-account", "describe", "--id", id, "--enable-auth-v2"))
+        return retry(() -> exec("service-account", "describe", "--id", id))
             .asJson(ServiceAccountData.class);
     }
 
     public ServiceAccountData[] listServiceAccount() throws CliGenericException {
-        return retry(() -> exec("service-account", "list", "-o", "json", "--enable-auth-v2"))
+        return retry(() -> exec("service-account", "list", "-o", "json"))
             .asJson(ServiceAccountData[].class);
     }
 


### PR DESCRIPTION
CLI >= [0.51.4-beta1](https://github.com/redhat-developer/app-services-cli/releases/tag/v0.51.4-beta1) uses the new Service Account SDK. 

The `--enable-auth-v2` flags have been deprecated and CLI should return output according to the new SDK by default.