### PR TITLE
Kafka instance suspension and resumption

### DIFF
--- a/src/main/java/io/managed/services/test/Environment.java
+++ b/src/main/java/io/managed/services/test/Environment.java
@@ -97,6 +97,9 @@ public class Environment {
     private static final String PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN_ENV = "PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN";
     private static final String PROMETHEUS_WEB_CLIENT_ROUTE_ENV = "PROMETHEUS_WEB_CLIENT_ROUTE";
 
+    private static final String STAGE_DATA_PLANE_ADMIN_CLIENT_ID_ENV = "STAGE_DATA_PLANE_ADMIN_CLIENT_ID";
+    private static final String STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET_ENV = "STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET";
+
     /*
      * Setup constants from env variables or set default
      */
@@ -190,6 +193,10 @@ public class Environment {
     public static final String PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN = getOrDefault(PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN_ENV, null);
     public static final String PROMETHEUS_WEB_CLIENT_ROUTE = getOrDefault(PROMETHEUS_WEB_CLIENT_ROUTE_ENV, "https://obs-prometheus-managed-application-services-observability.apps.mk-stage-0622.bd59.p1.openshiftapps.com");
 
+
+    // admin endpoint credentials (vault-key: clientid, secret) https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/jenkins/managed-services/secrets.yaml#L228-235
+    public static final String STAGE_DATA_PLANE_ADMIN_CLIENT_ID = getOrDefault(STAGE_DATA_PLANE_ADMIN_CLIENT_ID_ENV, null);
+    public static final String STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET = getOrDefault(STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET_ENV, null);
 
     private Environment() {
     }

--- a/src/main/java/io/managed/services/test/client/openshiftapiadmin/OpenshiftAdminEndpointApi.java
+++ b/src/main/java/io/managed/services/test/client/openshiftapiadmin/OpenshiftAdminEndpointApi.java
@@ -1,0 +1,101 @@
+package io.managed.services.test.client.openshiftapiadminendpoint;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.managed.services.test.Environment;
+import io.managed.services.test.client.exception.ApiUnknownException;
+import io.vertx.core.json.JsonObject;
+import lombok.extern.log4j.Log4j2;
+import okhttp3.Call;
+import okhttp3.Credentials;
+import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import java.io.IOException;
+
+@Log4j2
+public class AdminEndpointApi {
+    private final RedhatAuthApi redhatAuthApi = new RedhatAuthApi();
+    private final OkHttpClient okHttpClient = new OkHttpClient();
+
+    private String obtainRedhatAuthToken() throws IOException, ApiUnknownException {
+        return redhatAuthApi.getAdminAuthToken();
+    }
+
+    public void patchKafkaInstanceSuspension(String kafkaInstanceId, boolean suspended) throws IOException, ApiUnknownException {
+
+        // request body with suspension content
+        JsonObject json = new JsonObject()
+            .put("suspended", suspended);
+        final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+        RequestBody requestBody = RequestBody.create(JSON, json.toString());
+
+        final String API_HOST = Environment.OPENSHIFT_API_URI;
+        //String API_HOST="https://api.stage.openshift.com";
+
+        //request fresh token
+        String token = this.redhatAuthApi.getAdminAuthToken();
+
+        Request suspensionRequest = new Request.Builder()
+            .url( String.format("%s/api/kafkas_mgmt/v1/admin/kafkas/%s", Environment.OPENSHIFT_API_URI, kafkaInstanceId))
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", String.format("Bearer %s", token))
+            .patch(requestBody)
+            .build();
+
+        Response response = okHttpClient.newCall(suspensionRequest).execute();
+        String responseBodyString = response.body().string();
+    }
+
+}
+
+
+class RedhatAuthApi {
+    private final OkHttpClient okHttpClient = new OkHttpClient();
+
+    public String getAdminAuthToken() throws IOException, ApiUnknownException {
+
+        // post request credentials
+        String credential = Credentials.basic(Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_ID, Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET);
+
+        // post request body
+        RequestBody formBody = new FormBody.Builder()
+            .add("grant_type", "client_credentials")
+            .build();
+
+        // build request to obtain token which will be used to communicate with Kafka cluster admin endpoint
+        Request request = new Request.Builder()
+            .url("https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token")
+            .addHeader("Content-Type", "application/x-www-form-urlencoded")
+            .addHeader("Authorization", credential)
+            .post(formBody)
+            .build();
+
+        // send request to obtain token
+        Call call = okHttpClient.newCall(request);
+        Response response = call.execute();
+
+        if (response.code() != 200) {
+            throw new ApiUnknownException(
+                response.message(),
+                response.code(),
+                response.headers().toMultimap(),
+                response.body().toString(),
+                new Exception());
+        }
+
+        // parse the token from response
+        String responseBodyString = response.body().string();
+        ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        JsonNode jsonNode = objectMapper.readTree(responseBodyString);
+        return jsonNode.get("access_token").asText();
+
+    }
+
+
+}

--- a/src/main/java/io/managed/services/test/client/openshiftapiadmin/OpenshiftAdminEndpointApi.java
+++ b/src/main/java/io/managed/services/test/client/openshiftapiadmin/OpenshiftAdminEndpointApi.java
@@ -1,10 +1,9 @@
-package io.managed.services.test.client.openshiftapiadminendpoint;
+package io.managed.services.test.client.openshiftapiadmin;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.managed.services.test.Environment;
-import io.managed.services.test.client.exception.ApiUnknownException;
 import io.vertx.core.json.JsonObject;
 import lombok.extern.log4j.Log4j2;
 import okhttp3.Call;
@@ -15,61 +14,70 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import java.io.IOException;
 
 @Log4j2
-public class AdminEndpointApi {
-    private final RedhatAuthApi redhatAuthApi = new RedhatAuthApi();
-    private final OkHttpClient okHttpClient = new OkHttpClient();
+public class OpenshiftAdminEndpointApi {
 
-    private String obtainRedhatAuthToken() throws IOException, ApiUnknownException {
+    private final RedhatAuthApi redhatAuthApi;
+
+    private String obtainRedhatAuthToken() throws Exception {
         return redhatAuthApi.getAdminAuthToken();
     }
 
-    public void patchKafkaInstanceSuspension(String kafkaInstanceId, boolean suspended) throws IOException, ApiUnknownException {
+    public OpenshiftAdminEndpointApi(String rhAuthUsername, String rhAuthPassword) {
+        this.redhatAuthApi = new RedhatAuthApi(rhAuthUsername, rhAuthPassword);
+    }
+
+    public void patchKafkaInstanceSuspension(String kafkaInstanceId, boolean suspended) throws Exception {
 
         // request body with suspension content
         JsonObject json = new JsonObject()
             .put("suspended", suspended);
-        final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-        RequestBody requestBody = RequestBody.create(JSON, json.toString());
+        final MediaType jsonMediaType = MediaType.parse("application/json; charset=utf-8");
+        RequestBody requestBody = RequestBody.create(jsonMediaType, json.toString());
 
-        final String API_HOST = Environment.OPENSHIFT_API_URI;
-        //String API_HOST="https://api.stage.openshift.com";
+        log.info("request fresh token to communicate with admin endpoint");
+        String token = this.obtainRedhatAuthToken();
 
-        //request fresh token
-        String token = this.redhatAuthApi.getAdminAuthToken();
+        //request url
+        String requestUrl = String.format("%s/api/kafkas_mgmt/v1/admin/kafkas/%s", Environment.OPENSHIFT_API_URI, kafkaInstanceId);
 
         Request suspensionRequest = new Request.Builder()
-            .url( String.format("%s/api/kafkas_mgmt/v1/admin/kafkas/%s", Environment.OPENSHIFT_API_URI, kafkaInstanceId))
+            .url(requestUrl)
             .addHeader("Content-Type", "application/json")
             .addHeader("Authorization", String.format("Bearer %s", token))
             .patch(requestBody)
             .build();
 
-        Response response = okHttpClient.newCall(suspensionRequest).execute();
-        String responseBodyString = response.body().string();
+        Response response = new OkHttpClient().newCall(suspensionRequest).execute();
+        if (response.code() != 200)
+            throw new Exception(String.format("response code %d while patching kafka at admin endpoint %s", response.code(), requestUrl));
+        log.info("kafka instance '{}', patched", kafkaInstanceId);
     }
-
 }
 
-
+@Log4j2
 class RedhatAuthApi {
+
     private final OkHttpClient okHttpClient = new OkHttpClient();
+    private final String credentialsName;
+    private final String credentialsPassword;
 
-    public String getAdminAuthToken() throws IOException, ApiUnknownException {
+    public RedhatAuthApi(String credentialsName, String credentialsPassword) {
+        this.credentialsName = credentialsName;
+        this.credentialsPassword = credentialsPassword;
+    }
 
-        // post request credentials
-        String credential = Credentials.basic(Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_ID, Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET);
+    public String getAdminAuthToken() throws Exception {
 
-        // post request body
-        RequestBody formBody = new FormBody.Builder()
-            .add("grant_type", "client_credentials")
-            .build();
+        // request components
+        String credential = Credentials.basic(credentialsName, credentialsPassword);
+        RequestBody formBody = new FormBody.Builder().add("grant_type", "client_credentials").build();
+        String requestUrl = "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token";
 
         // build request to obtain token which will be used to communicate with Kafka cluster admin endpoint
         Request request = new Request.Builder()
-            .url("https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token")
+            .url(requestUrl)
             .addHeader("Content-Type", "application/x-www-form-urlencoded")
             .addHeader("Authorization", credential)
             .post(formBody)
@@ -79,23 +87,15 @@ class RedhatAuthApi {
         Call call = okHttpClient.newCall(request);
         Response response = call.execute();
 
-        if (response.code() != 200) {
-            throw new ApiUnknownException(
-                response.message(),
-                response.code(),
-                response.headers().toMultimap(),
-                response.body().toString(),
-                new Exception());
-        }
+        if (response.code() != 200)
+            throw new Exception(String.format("response code %d while obtaining token from %s", response.code(), requestUrl));
 
         // parse the token from response
+        log.info("token successfully obtained");
         String responseBodyString = response.body().string();
         ObjectMapper objectMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         JsonNode jsonNode = objectMapper.readTree(responseBodyString);
         return jsonNode.get("access_token").asText();
-
     }
-
-
 }

--- a/src/test/java/io/managed/services/test/kafka/KafkaOverseeingTest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaOverseeingTest.java
@@ -1,0 +1,99 @@
+package io.managed.services.test.kafka;
+
+import com.openshift.cloud.api.kas.models.KafkaRequest;
+import io.managed.services.test.Environment;
+import io.managed.services.test.TestBase;
+import io.managed.services.test.client.openshiftapiadmin.OpenshiftAdminEndpointApi;
+import io.managed.services.test.client.kafkainstance.KafkaInstanceApi;
+import io.managed.services.test.client.kafkainstance.KafkaInstanceApiUtils;
+import io.managed.services.test.client.kafkamgmt.KafkaMgmtApi;
+import io.managed.services.test.client.kafkamgmt.KafkaMgmtApiUtils;
+import io.managed.services.test.client.oauth.KeycloakLoginSession;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.managed.services.test.TestUtils.assumeTeardown;
+import static io.managed.services.test.TestUtils.bwait;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Log4j2
+public class KafkaOverseeingTest extends TestBase {
+
+    static final String KAFKA_INSTANCE_NAME = "mk-e2e-ow-" + Environment.LAUNCH_KEY;
+
+    private KafkaRequest kafka;
+    private KafkaInstanceApi kafkaInstanceApi;
+    private KafkaMgmtApi kafkaMgmtApi;
+    private OpenshiftAdminEndpointApi adminEndpointApi;
+
+    @BeforeClass
+    @SneakyThrows
+    public void bootstrap() {
+
+        assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
+        assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
+        assertNotNull(Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_ID, "the STAGE_DATA_PLANE_ADMIN_CLIENT_ID env is null");
+        assertNotNull(Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET, "the STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET env is null");
+
+        var auth = new KeycloakLoginSession(Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
+
+        // initialize the mgmt APIs
+        var user = bwait(auth.loginToRedHatSSO());
+        kafkaMgmtApi = KafkaMgmtApiUtils.kafkaMgmtApi(Environment.OPENSHIFT_API_URI, user);
+
+        log.info("create kafka instance '{}'", KAFKA_INSTANCE_NAME);
+        kafka = KafkaMgmtApiUtils.applyKafkaInstance(kafkaMgmtApi, KAFKA_INSTANCE_NAME);
+        kafkaInstanceApi = bwait(KafkaInstanceApiUtils.kafkaInstanceApi(auth, kafka));
+
+        // initialize client to communicate with admin endpoint on openshift uri.
+        adminEndpointApi = new OpenshiftAdminEndpointApi(
+            Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_ID,
+            Environment.STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET
+        );
+    }
+
+    @AfterClass(alwaysRun = true)
+    @SneakyThrows
+    public void teardown() {
+
+        assumeTeardown();
+        // clean kafka instance
+        try {
+            KafkaMgmtApiUtils.cleanKafkaInstance(this.kafkaMgmtApi, KAFKA_INSTANCE_NAME);
+        } catch (Throwable t) {
+            log.error("clean main kafka instance error: ", t);
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void testSuspendKafkaInstance() {
+
+        log.info("kafka instance with name'{}', and id '{}' is to be suspended", kafka.getName(), kafka.getId());
+        this.adminEndpointApi.patchKafkaInstanceSuspension(kafka.getId(), true);
+
+        log.info("wait until kafka status is stated to be suspended");
+        String newKafkaState = KafkaMgmtApiUtils.waitUntilKafkaIsSuspended(this.kafkaMgmtApi, this.kafka.getId());
+        assertEquals(newKafkaState, "suspended");
+    }
+
+    @SneakyThrows
+    @Test(dependsOnMethods = "testSuspendKafkaInstance")
+    public void testResumeKafkaInstance() {
+
+        log.info("kafka instance with name'{}', and id '{}' is to be resumed", kafka.getName(), kafka.getId());
+        this.adminEndpointApi.patchKafkaInstanceSuspension(kafka.getId(), false);
+
+        // validate that status is suspended, which should be immediate
+        log.info("wait until kafka status is stated to be suspended");
+        String newKafkaState = KafkaMgmtApiUtils.waitUntilKafkaIsResumed(this.kafkaMgmtApi, this.kafka.getId());
+        assertEquals(newKafkaState, "ready");
+
+        log.info("try to call kafka instance api after kafka instance is resumed");
+        kafkaInstanceApi.getTopics();
+    }
+}

--- a/suites/kafka.xml
+++ b/suites/kafka.xml
@@ -6,6 +6,11 @@
             <class name="io.managed.services.test.SSOAuthTest"/>
         </classes>
     </test>
+    <test name="KafkaOverseeingTest">
+        <classes>
+            <class name="io.managed.services.test.kafka.KafkaOverseeingTest"/>
+        </classes>
+    </test>
     <test name="KafkaMgmtAPITest">
         <classes>
             <class name="io.managed.services.test.kafka.KafkaMgmtAPITest"/>


### PR DESCRIPTION
added tests for suspension and resuming of kafka instance. 

STAGE_DATA_PLANE_ADMIN_CLIENT_ID_ENV
STAGE_DATA_PLANE_ADMIN_CLIENT_SECRET

are only draft names due to current usage so if you have some suggestions for better name would be quite helpful. 

