### PR TITLE
creation of new test suite to provide smoke tests in production env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,23 @@
         </profile>
 
         <profile>
+            <id>production</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>suites/production.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>integration</id>
             <build>
                 <plugins>

--- a/src/test/java/io/managed/services/test/SSOAuthTest.java
+++ b/src/test/java/io/managed/services/test/SSOAuthTest.java
@@ -43,7 +43,7 @@ public class SSOAuthTest extends TestBase {
         LOGGER.info("user authenticated against: {}", Environment.OPENSHIFT_IDENTITY_URI);
     }
 
-    @Test
+    @Test(groups = "production")
     public void testJoinedLogin() throws Throwable {
         var auth = new KeycloakLoginSession(Vertx.vertx(), Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD);
 

--- a/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
+++ b/src/test/java/io/managed/services/test/kafka/KafkaMgmtAPITest.java
@@ -106,7 +106,7 @@ public class KafkaMgmtAPITest extends TestBase {
     private KafkaInstanceApi kafkaInstanceApi;
 
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void bootstrap() {
         assertNotNull(Environment.PRIMARY_USERNAME, "the PRIMARY_USERNAME env is null");
         assertNotNull(Environment.PRIMARY_PASSWORD, "the PRIMARY_PASSWORD env is null");
@@ -164,7 +164,7 @@ public class KafkaMgmtAPITest extends TestBase {
         }
     }
 
-    @Test
+    @Test(groups = "production")
     @SneakyThrows
     public void testCreateKafkaInstance() {
 
@@ -181,7 +181,7 @@ public class KafkaMgmtAPITest extends TestBase {
             Environment.PRIMARY_USERNAME, Environment.PRIMARY_PASSWORD));
     }
 
-    @Test
+    @Test(groups = "production")
     @SneakyThrows
     public void testCreateServiceAccount() {
 
@@ -192,7 +192,7 @@ public class KafkaMgmtAPITest extends TestBase {
                 .description("E2E test service account"));
     }
 
-    @Test(dependsOnMethods = {"testCreateServiceAccount", "testCreateKafkaInstance"})
+    @Test(dependsOnMethods = {"testCreateServiceAccount", "testCreateKafkaInstance"}, groups = "production")
     @SneakyThrows
     public void testCreateProducerAndConsumerACLs() {
 
@@ -203,7 +203,7 @@ public class KafkaMgmtAPITest extends TestBase {
         KafkaInstanceApiAccessUtils.createProducerAndConsumerACLs(kafkaInstanceApi, principal);
     }
 
-    @Test(dependsOnMethods = "testCreateKafkaInstance")
+    @Test(dependsOnMethods = "testCreateKafkaInstance", groups = "production")
     @SneakyThrows
     public void testCreateTopics() {
 
@@ -374,7 +374,7 @@ public class KafkaMgmtAPITest extends TestBase {
         KafkaMgmtMetricsUtils.testMessageInTotalMetric(kafkaMgmtApi, kafka, serviceAccount, TOPIC_NAME);
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateProducerAndConsumerACLs"})
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateProducerAndConsumerACLs"}, groups = "production")
     @SneakyThrows
     public void testMessagingKafkaInstanceUsingOAuth() {
 
@@ -413,7 +413,7 @@ public class KafkaMgmtAPITest extends TestBase {
             KafkaAuthMethod.OAUTH)));
     }
 
-    @Test(dependsOnMethods = {"testCreateTopics", "testCreateProducerAndConsumerACLs"})
+    @Test(dependsOnMethods = {"testCreateTopics", "testCreateProducerAndConsumerACLs"}, groups = "production")
     @SneakyThrows
     public void testMessagingKafkaInstanceUsingPlainAuth() {
 
@@ -479,7 +479,7 @@ public class KafkaMgmtAPITest extends TestBase {
         }
     }
 
-    @Test(dependsOnMethods = {"testCreateKafkaInstance"})
+    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, groups = "production")
     @SneakyThrows
     public void testListAndSearchKafkaInstance() {
 
@@ -558,7 +558,7 @@ public class KafkaMgmtAPITest extends TestBase {
         waitFor("kafka reauthentication to be disabled", ofSeconds(10), ofMinutes(5), isReauthenticationDisabled);
     }
 
-    @Test(dependsOnMethods = "testCreateTopics")
+    @Test(dependsOnMethods = "testCreateTopics", groups = "production")
     @SneakyThrows
     public void testDeleteServiceAccount() {
 
@@ -621,7 +621,7 @@ public class KafkaMgmtAPITest extends TestBase {
         });
     }
 
-    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, priority = 2)
+    @Test(dependsOnMethods = {"testCreateKafkaInstance"}, groups = "production", priority = 2)
     @SneakyThrows
     public void testDeleteKafkaInstance() {
         if (Environment.SKIP_KAFKA_TEARDOWN) {

--- a/suites/production.xml
+++ b/suites/production.xml
@@ -1,0 +1,27 @@
+<!-- Suite -->
+<suite name="Production">
+
+    <!--  groups to be executed  -->
+    <groups>
+        <run>
+            <include name="production"  />
+        </run>
+    </groups>
+
+    <!--  test classes to watch for  -->
+    <test name="SSOAuthTest">
+        <classes>
+            <class name="io.managed.services.test.SSOAuthTest"/>
+        </classes>
+    </test>
+    <test name="KafkaMgmtAPITest">
+        <classes>
+            <class name="io.managed.services.test.kafka.KafkaMgmtAPITest"/>
+        </classes>
+    </test>
+    <test name="RegistryMgmtAPITest">
+        <classes>
+            <class name="io.managed.services.test.registry.RegistryMgmtAPITest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
new profile (maven) with name `production` is created which executes `production` test suite.  This profile will be invoked by having PROFILE=production environment variable set. 

`production` Test suite looks for  tests which belongs to the `production` testing group.  This includes basic test such as logging to to MAS SSO, creating kafka, service acc, topics sending messages , listing resources (10 tests total).



 