### PR TITLE
billing metric tests, pointed to new prometheus route, change of sett…

### DIFF
--- a/src/main/java/io/managed/services/test/Environment.java
+++ b/src/main/java/io/managed/services/test/Environment.java
@@ -94,6 +94,7 @@ public class Environment {
     private static final String STRATOSPHERE_SCENARIO_4_AWS_ACCOUNT_ID_ENV = "STRATOSPHERE_SCENARIO_4_AWS_ACCOUNT_ID";
 
     private static final String PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN_ENV = "PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN";
+    private static final String PROMETHEUS_WEB_CLIENT_ROUTE_ENV = "PROMETHEUS_WEB_CLIENT_ROUTE";
 
     /*
      * Setup constants from env variables or set default
@@ -184,6 +185,8 @@ public class Environment {
     public static final String STRATOSPHERE_SCENARIO_4_AWS_ACCOUNT_ID = getOrDefault(STRATOSPHERE_SCENARIO_4_AWS_ACCOUNT_ID_ENV, null);
 
     public static final String PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN = getOrDefault(PROMETHEUS_WEB_CLIENT_ACCESS_TOKEN_ENV, null);
+    public static final String PROMETHEUS_WEB_CLIENT_ROUTE = getOrDefault(PROMETHEUS_WEB_CLIENT_ROUTE_ENV, "https://obs-prometheus-managed-application-services-observability.apps.mk-stage-0622.bd59.p1.openshiftapps.com");
+
 
     private Environment() {
     }


### PR DESCRIPTION
**changes:** 

1. **prometheus route address:** part of tests from biling metrics need to query prometheus server directly. This is accessible through the route which was changed recently. From now on set as environment variable with default to current route url. 
2. **refactor:** tabs standardized + local variables from instance field with only one usage (creation of kafka and service account). Addition of TODO mention regarding renaming of metrics which will be of our concern in nearby future. 
