### PR TITLE
add provider option into the cli tests when creating kafka instance

### DIFF
--- a/src/main/java/io/managed/services/test/cli/CLI.java
+++ b/src/main/java/io/managed/services/test/cli/CLI.java
@@ -127,7 +127,7 @@ public class CLI {
     }
 
     public KafkaRequest createKafka(String name) throws CliGenericException {
-        return retryKafkaCreation(() -> exec("kafka", "create", "--bypass-checks", "--name", name, "--region", Environment.DEFAULT_KAFKA_REGION))
+        return retryKafkaCreation(() -> exec("kafka", "create", "--bypass-checks", "--name", name, "--provider", Environment.CLOUD_PROVIDER, "--region", Environment.DEFAULT_KAFKA_REGION))
             .asJson(KafkaRequest.class);
     }
 


### PR DESCRIPTION
in order to be able to cli tests targeting (i.e. using) gcp/aws provider for kafka instances. 