### PR TITLE
pointing of crd crawler back to the main repo holding crds for kafkac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,9 +319,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <!-- Temporary usage og forked repo to obtain descriptive enough version of crds to build specific enough Models -->
                             <url>https://raw.githubusercontent.com/redhat-developer/app-services-operator/main/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.kafkaconnections.crd.yaml</url>
-<!--                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.kafkaconnections.crd.yaml</url>-->
                             <outputFileName>rhoas-operator.kafkaconnections.crd.yaml</outputFileName>
                             <outputDirectory>${project.build.directory}/manifests</outputDirectory>
                         </configuration>
@@ -333,9 +331,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <!-- The same temporary change as in case of kafkaconnections -->
                             <url>https://raw.githubusercontent.com/redhat-developer/app-services-operator/main/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.serviceregistryconnections.crd.yaml</url>
-<!--                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.serviceregistryconnections.crd.yaml</url>-->
                             <outputFileName>rhoas-operator.serviceregistryconnections.crd.yaml</outputFileName>
                             <outputDirectory>${project.build.directory}/manifests</outputDirectory>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.checkstyle.version>3.2.0</maven.checkstyle.version>
         <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
         <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
-        <fabric8.version>6.2.0</fabric8.version>
+        <fabric8.version>6.3.0</fabric8.version>
         <sundrio.version>0.93.1</sundrio.version>
         <!-- See 'Update the rhoas-model dependency' in the README.md on how to build and update the rhoas-model -->
         <rhoas-model.version>0.9.7</rhoas-model.version>
@@ -320,7 +320,8 @@
                         </goals>
                         <configuration>
                             <!-- Temporary usage og forked repo to obtain descriptive enough version of crds to build specific enough Models -->
-                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.kafkaconnections.crd.yaml</url>
+                            <url>https://raw.githubusercontent.com/redhat-developer/app-services-operator/main/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.kafkaconnections.crd.yaml</url>
+<!--                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.kafkaconnections.crd.yaml</url>-->
                             <outputFileName>rhoas-operator.kafkaconnections.crd.yaml</outputFileName>
                             <outputDirectory>${project.build.directory}/manifests</outputDirectory>
                         </configuration>
@@ -333,7 +334,8 @@
                         </goals>
                         <configuration>
                             <!-- The same temporary change as in case of kafkaconnections -->
-                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.serviceregistryconnections.crd.yaml</url>
+                            <url>https://raw.githubusercontent.com/redhat-developer/app-services-operator/main/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.serviceregistryconnections.crd.yaml</url>
+<!--                            <url>https://raw.githubusercontent.com/henryZrncik/app-services-operator/kafka-connection-crd-status-metadata-explicit/olm/olm-catalog/rhoas-operator/${rhoas-model.version}/manifests/rhoas-operator.serviceregistryconnections.crd.yaml</url>-->
                             <outputFileName>rhoas-operator.serviceregistryconnections.crd.yaml</outputFileName>
                             <outputDirectory>${project.build.directory}/manifests</outputDirectory>
                         </configuration>

--- a/src/test/java/io/managed/services/test/devexp/ServiceRegistryOperatorTest.java
+++ b/src/test/java/io/managed/services/test/devexp/ServiceRegistryOperatorTest.java
@@ -5,6 +5,7 @@ import com.redhat.rhoas.v1alpha1.CloudServiceAccountRequest;
 import com.redhat.rhoas.v1alpha1.CloudServiceAccountRequestSpec;
 import com.redhat.rhoas.v1alpha1.CloudServicesRequest;
 import com.redhat.rhoas.v1alpha1.CloudServicesRequestSpec;
+import com.redhat.rhoas.v1alpha1.ServiceRegistryConnection;
 import com.redhat.rhoas.v1alpha1.ServiceRegistryConnectionBuilder;
 import com.redhat.rhoas.v1alpha1.serviceregistryconnectionspec.CredentialsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -146,7 +147,7 @@ public class ServiceRegistryOperatorTest extends TestBase {
     }
 
     private void cleanServiceRegistryConnection() {
-        var c = OperatorUtils.serviceRegistryConnection(oc).withName(SERVICE_REGISTRY_CONNECTION_NAME).get();
+        ServiceRegistryConnection c = OperatorUtils.serviceRegistryConnection(oc).withName(SERVICE_REGISTRY_CONNECTION_NAME).get();
         if (c != null) {
             LOGGER.info("clean ServiceRegistryConnection: {}", c.getMetadata().getName());
             OperatorUtils.serviceRegistryConnection(oc).delete(c);


### PR DESCRIPTION
pointing of crd crawler back to the main repo holding crds for kafkaconnections and serviceregistryconnection, update fabric8 to 6.3 which fixes known bug (https://github.com/fabric8io/kubernetes-client/issues/4543) which was the reason we introduced this temporary workaround. 