### PR TITLE
change of billing metric from haproxy_server to haproxy_backend

### DIFF
--- a/src/test/java/io/managed/services/test/billing/BillingMetricsTest.java
+++ b/src/test/java/io/managed/services/test/billing/BillingMetricsTest.java
@@ -76,8 +76,8 @@ public class BillingMetricsTest extends TestBase {
 
     // TODO metrics will soon be renamed to match new naming convention, more at MGDSTRM-7080.
     private static final String METRIC_STORAGE = "kafka_broker_quota_totalstorageusedbytes";
-    private static final String METRIC_TRAFFIC_IN = "haproxy_server_bytes_in_total";
-    private static final String METRIC_TRAFFIC_OUT = "haproxy_server_bytes_out_total";
+    private static final String METRIC_TRAFFIC_IN = "haproxy_backend_bytes_in_total";
+    private static final String METRIC_TRAFFIC_OUT = "haproxy_backend_bytes_out_total";
     private static final String METRIC_CLUSTER_HOURS = "kafka_id:strimzi_resource_state:max_over_time1h";
 
     // size and count of messages to be produced/ consumed


### PR DESCRIPTION
renaming of billing metric according to new metric source. 

removal of `haproxy_server_bytes_in_total` and `haproxy_server_bytes_in_total` from metrics federated to user on endopoint `/api/kafkas_mgmt/v1/kafkas/{id}/metrics/federate`