### PR TITLE
temporary copy paste approach to obtain mk kafka, agent models  for i…

### DIFF
--- a/hack/stage-cluster-rbac-resources.yaml
+++ b/hack/stage-cluster-rbac-resources.yaml
@@ -22,6 +22,10 @@ rules:
   - apiGroups: ["managedkafka.bf2.org"]
     resources: ["managedkafkas", "managedkafkaagents"]
     verbs: ["list","get"]
+  # machinesets resources in order to query them in tests related to node autoscaling.
+  - apiGroups: ["machine.openshift.io"]
+    resources: ["machinesets"]
+    verbs: ["list","get"]
   # be able to view state of pods which actually holds resources reserved by managedkafka
   - apiGroups: [""]
     resources: ["pods","events","secrets","services"]

--- a/src/main/java/io/managed/services/test/k8/managedkafka/ManagedKafkaUtils.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/ManagedKafkaUtils.java
@@ -5,7 +5,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.managed.services.test.k8.managedkafka.resources.v1alpha1.ManagedKafka;
+import io.managed.services.test.k8.managedkafka.v1alpha1.ManagedKafka;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafka.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafka.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.fabric8.kubernetes.api.model.Namespaced;
@@ -6,10 +6,9 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
-import io.managed.services.test.k8.managedkafka.ManagedKafkaKeys;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-
+import io.managed.services.test.k8.managedkafka.ManagedKafkaKeys;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -123,7 +122,6 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
         return Optional.ofNullable(this.getMetadata().getLabels())
                         .map(labels -> labels.get(label));
     }
-
 
 
 

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgent.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgent.java
@@ -1,0 +1,38 @@
+package io.managed.services.test.k8.managedkafka.v1alpha1;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.managed.services.test.k8.managedkafka.ManagedKafkaKeys;
+
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs = @BuildableReference(CustomResource.class),
+        editableEnabled = false
+)
+@Group(ManagedKafkaKeys.GROUP)
+@Version("v1alpha1")
+public class ManagedKafkaAgent extends CustomResource<ManagedKafkaAgentSpec, ManagedKafkaAgentStatus>
+        implements Namespaced {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected ManagedKafkaAgentSpec initSpec() {
+        return new ManagedKafkaAgentSpec();
+    }
+
+    /**
+     * A null value will be treated as empty instead
+     */
+    @Override
+    public void setSpec(ManagedKafkaAgentSpec spec) {
+        if (spec == null) {
+            spec = initSpec();
+        }
+        super.setSpec(spec);
+    }
+
+}

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentList.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentList.java
@@ -1,0 +1,6 @@
+package io.managed.services.test.k8.managedkafka.v1alpha1;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class ManagedKafkaAgentList extends CustomResourceList<ManagedKafkaAgent> {
+}

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentSpec.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentSpec.java
@@ -1,0 +1,30 @@
+package io.managed.services.test.k8.managedkafka.v1alpha1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
+@ToString
+@EqualsAndHashCode
+@JsonInclude(Include.NON_NULL)
+@Getter
+@Setter
+public class ManagedKafkaAgentSpec {
+    @NotNull
+    ObservabilityConfiguration observability;
+    Map<String, Profile> capacity = new LinkedHashMap<>();
+    NetworkConfiguration net;
+}

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentStatus.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAgentStatus.java
@@ -1,0 +1,26 @@
+package io.managed.services.test.k8.managedkafka.v1alpha1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@Setter
+public class ManagedKafkaAgentStatus {
+
+    private List<ManagedKafkaCondition> conditions;
+
+    private String updatedTimestamp;
+
+    private List<StrimziVersionStatus> strimzi;
+
+    private Map<String, ProfileCapacity> capacity = new LinkedHashMap<>();
+
+}

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAuthenticationOAuth.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaAuthenticationOAuth.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaCapacity.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaCapacity.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.kubernetes.api.model.Quantity;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaCondition.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaCondition.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaEndpoint.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaEndpoint.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -7,16 +7,23 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
+/**
+ * Defines the endpoint related information used for reaching the ManagedKafka instance
+ */
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
-        editableEnabled = false)
+        editableEnabled = false
+)
 @ToString
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
-public class Profile {
+public class ManagedKafkaEndpoint {
 
-    Integer maxNodes;
-
+    @NotNull
+    private String bootstrapServerHost;
+    private TlsKeyPair tls;
 }

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaList.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaList.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import io.fabric8.kubernetes.client.CustomResourceList;
 

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaRoute.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaRoute.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaSpec.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaSpec.java
@@ -1,10 +1,11 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaStatus.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ManagedKafkaStatus.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/NetworkConfiguration.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/NetworkConfiguration.java
@@ -1,15 +1,14 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
-/**
- * Represents a TLS keys pair, both public (signed certificate) and private
- */
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
         editableEnabled = false
@@ -19,11 +18,8 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
-public class TlsKeyPair {
-
-    private String cert;
-    private String key;
-    private SecretKeySelector certRef;
-    private SecretKeySelector keyRef;
-
+@Accessors(prefix = "_")
+public class NetworkConfiguration {
+    @JsonProperty("private")
+    private boolean privatee;
 }

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ObservabilityConfiguration.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ObservabilityConfiguration.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -9,9 +9,6 @@ import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
 
-/**
- * Defines the endpoint related information used for reaching the ManagedKafka instance
- */
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
         editableEnabled = false
@@ -21,9 +18,12 @@ import javax.validation.constraints.NotNull;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
-public class ManagedKafkaEndpoint {
-
+public class ObservabilityConfiguration {
     @NotNull
-    private String bootstrapServerHost;
-    private TlsKeyPair tls;
+    private String accessToken;
+    private String channel;
+    @NotNull
+    private String repository;
+    private String tag;
+
 }

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/Profile.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/Profile.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -7,23 +7,16 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.validation.constraints.NotNull;
-
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
-        editableEnabled = false
-)
+        editableEnabled = false)
 @ToString
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
-public class ObservabilityConfiguration {
-    @NotNull
-    private String accessToken;
-    private String channel;
-    @NotNull
-    private String repository;
-    private String tag;
+public class Profile {
+
+    Integer maxNodes;
 
 }

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ProfileCapacity.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ProfileCapacity.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/SecretKeySelector.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/SecretKeySelector.java
@@ -1,5 +1,5 @@
 
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ServiceAccount.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/ServiceAccount.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/StrimziVersionComparator.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/StrimziVersionComparator.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import java.io.Serializable;
 import java.util.Comparator;

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/StrimziVersionStatus.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/StrimziVersionStatus.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -8,6 +8,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.List;
 
 /**

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/TlsKeyPair.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/TlsKeyPair.java
@@ -1,0 +1,29 @@
+package io.managed.services.test.k8.managedkafka.v1alpha1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Represents a TLS keys pair, both public (signed certificate) and private
+ */
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@Setter
+public class TlsKeyPair {
+
+    private String cert;
+    private String key;
+    private SecretKeySelector certRef;
+    private SecretKeySelector keyRef;
+
+}

--- a/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/Versions.java
+++ b/src/main/java/io/managed/services/test/k8/managedkafka/v1alpha1/Versions.java
@@ -1,4 +1,4 @@
-package io.managed.services.test.k8.managedkafka.resources.v1alpha1;
+package io.managed.services.test.k8.managedkafka.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -8,6 +8,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Matcher;

--- a/src/test/java/io/managed/services/test/cluster/DeploymentsTest.java
+++ b/src/test/java/io/managed/services/test/cluster/DeploymentsTest.java
@@ -9,7 +9,7 @@ import io.managed.services.test.TestBase;
 import io.managed.services.test.client.ApplicationServicesApi;
 import io.managed.services.test.client.kafkamgmt.KafkaMgmtApi;
 import io.managed.services.test.client.kafkamgmt.KafkaMgmtApiUtils;
-import io.managed.services.test.k8.managedkafka.resources.v1alpha1.ManagedKafka;
+import io.managed.services.test.k8.managedkafka.v1alpha1.ManagedKafka;
 import io.managed.services.test.k8.managedkafka.ManagedKafkaUtils;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;


### PR DESCRIPTION
models from fleetshard repo in order to use them to manipulate with `managedkafka` , `managedkafkaagent` in data plane cluster. 

The solution is temporary to complete and test tasks
 https://issues.redhat.com/browse/MGDSTRM-9281
 https://issues.redhat.com/browse/MGDSTRM-8992
 
 and will be switched to either more automated manner either with usage of git submodule or other approach (depending on https://issues.redhat.com/browse/MGDSTRM-10349 ) 
 
 additionally extension of role of account used in e2e test allso to have permission to list machine sets (in order to verify node scaling for future for   https://issues.redhat.com/browse/MGDSTRM-9281 
 
 regarding models: in this case only `managedkafkaagent` part  is added (as `managedkafka` and  classes it consitutes of are already present)