### PR TITLE
fix too long instance name 

### DIFF
--- a/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
+++ b/src/test/java/io/managed/services/test/devexp/KafkaCLITest.java
@@ -59,7 +59,7 @@ import static org.testng.Assert.assertTrue;
 public class KafkaCLITest extends TestBase {
     private static final Logger LOGGER = LogManager.getLogger(KafkaCLITest.class);
 
-    private static final String KAFKA_INSTANCE_NAME = "cli-e2e-test-instance-"  + Environment.LAUNCH_SUFFIX;
+    private static final String KAFKA_INSTANCE_NAME = "cli-e2e-test-" + Environment.LAUNCH_SUFFIX;
     private static final String SERVICE_ACCOUNT_NAME = "cli-e2e-service-account-"  + Environment.LAUNCH_SUFFIX;
     private static final String TOPIC_NAME = "cli-e2e-test-topic";
     // used for testing quickstart for data production and consumption


### PR DESCRIPTION
after switching to addition of data provider name as suffix to instance names. 