### PR TITLE
fix: billing model semantics after kfm billing model changes

### DIFF
--- a/src/main/java/io/managed/services/test/client/exception/ApiGenericException.java
+++ b/src/main/java/io/managed/services/test/client/exception/ApiGenericException.java
@@ -12,6 +12,8 @@ public class ApiGenericException extends Exception {
     private final String responseBody;
 
     public final static String API_ERROR_BILLING_ACCOUNT_INVALID = "43";
+    public final static String API_ERROR_INSUFFICIENT_QUOTA = "120";
+
 
     public ApiGenericException(ApiUnknownException e) {
         super(e.getFullMessage(), e);

--- a/src/test/java/io/managed/services/test/kafka/QuotaKafkaInstanceTest.java
+++ b/src/test/java/io/managed/services/test/kafka/QuotaKafkaInstanceTest.java
@@ -55,7 +55,7 @@ public class QuotaKafkaInstanceTest extends TestBase {
     
     // Kafka API code errors
     private static final String KAFKAS_MGMT_120_CODE = "KAFKAS-MGMT-120";
-    private static final String KAFKAS_MGMT_120_REASON = "Insufficient quota: error getting billing model: No available billing model found";
+    private static final String KAFKAS_MGMT_120_REASON = "error getting billing model";
     private static final String KAFKAS_MGMT_21_CODE = "KAFKAS-MGMT-21";
     private static final String KAFKAS_MGMT_21_REASON = "unable to detect instance type in plan provided: ";
 


### PR DESCRIPTION
Billing model logic has change after the recent merge of long lived eval instance support