### PR TITLE
update bootstrap scripts to reflect change in organization of tokens and service accounts in openshift resources

### DIFF
--- a/hack/bootstrap-mk-e2e-tests-namespace.sh
+++ b/hack/bootstrap-mk-e2e-tests-namespace.sh
@@ -32,9 +32,12 @@ fi
 
 SECRET_NAME=$(oc get serviceaccount "${SERVICE_ACCOUNT_NAME}" \
   --namespace "${NAMESPACE_NAME}" \
-  -o json | jq -r '.secrets[] | select(.name | contains("token")) | .name')
+  -o json | jq -r '.secrets[0].name')
 
-TOKEN_DATA=$(oc get secret "${SECRET_NAME}" \
+# Extract the value of openshift.io/token-secret.name which holds name of actual secret token
+TOKEN_SECRET_NAME=$(oc get secret ${SECRET_NAME} -n ${NAMESPACE_NAME} -o json | jq -r '.metadata.annotations."openshift.io/token-secret.name"')
+
+TOKEN_DATA=$(oc get secret "${TOKEN_SECRET_NAME}" \
   --namespace "${NAMESPACE_NAME}" \
   -o jsonpath='{.data.token}')
 

--- a/hack/obtain-stage-cluster-k8-token.sh
+++ b/hack/obtain-stage-cluster-k8-token.sh
@@ -2,32 +2,35 @@
 
 # obtain token to communicte with prometheus server
 # execute this script from /hack 
-# firstly user need to have access (via oc) to the given cluster (in this case it is stage). 
+# firstly user need to have access (via oc) to the given cluster (in this case it is AWS stage data plane cluster).
 
 # create kubernetes resources (RBACs, namespace) necessary to create token
 oc apply -f stage-cluster-rbac-resources.yaml
 
 # obtain secret
-SECRET_NAME=$(oc get sa e2e-query-sa --namespace e2e-querry-ns -o json | jq '.secrets[] | select(.name | contains("token")) | .name')
-SECRET_NAME=$(sed -e 's/^"//' -e 's/"$//' <<< ${SECRET_NAME})
-echo
+SECRET_NAME=$(oc get sa e2e-query-sa --namespace e2e-querry-ns -o json | jq -r '.secrets[0].name')
 echo "obtained SECRET_NAME:"
-echo
 echo ${SECRET_NAME}
 echo "---"
+echo
+
+# # Extract the value of openshift.io/token-secret.name which holds name of actual secret token
+TOKEN_SECRET_NAME=$(oc get secret ${SECRET_NAME} -n e2e-querry-ns -o json | jq -r '.metadata.annotations."openshift.io/token-secret.name"')
+echo "obtained SECRET_NAME (token):"
+echo ${TOKEN_SECRET_NAME}
+echo "---"
+echo
 
 # obtain token data
-TOKEN_DATA=$(oc get secret ${SECRET_NAME} --namespace prom-query-ns  -o jsonpath='{.data.token}')
-echo
+TOKEN_DATA=$(oc get secret ${TOKEN_SECRET_NAME} --namespace e2e-querry-ns  -o jsonpath='{.data.token}')
 echo "obtained TOKEN_DATA:"
-echo
 echo "${TOKEN_DATA}"
 echo "---"
+echo
 
 # decode token from base-64
 TOKEN=$(echo "${TOKEN_DATA}" | base64 -d)
-echo
-echo "obtained TOKEN itself:"
-echo
+echo "obtained TOKEN (decoded) data:"
 echo "${TOKEN}"
 echo "---"
+echo


### PR DESCRIPTION
instead of searching for secret containing *token* in its name we search for the only secret in given svc acc and later obtain name of token from annotation of given secret.

This change is done due to fact that service account no longer holds name of its access token (secret) directly in its description.