### PR TITLE
increase timeout for connecion and read of kafka scripts binaries

### DIFF
--- a/src/main/java/io/managed/services/test/cli/KafkaScripts.java
+++ b/src/main/java/io/managed/services/test/cli/KafkaScripts.java
@@ -96,8 +96,8 @@ public class KafkaScripts {
         FileUtils.copyURLToFile(
                 new URL(kafkaURLString),
                 source.toFile(),
-                10000,
-                10000);
+                30000,
+                30000);
 
         LOGGER.info("extract binaries");
 


### PR DESCRIPTION
3 failures in last week due to downloading taking too long, 
run four times with this new timeout, error did not appear so fat but will be monitored. 