### PR TITLE
Data plane cluster capacity test simplified

### DIFF
--- a/src/main/java/io/managed/services/test/dataplane/FleetshardUtils.java
+++ b/src/main/java/io/managed/services/test/dataplane/FleetshardUtils.java
@@ -29,7 +29,7 @@ public class FleetshardUtils {
     public static int getStreamingUnitCountOfExistingGivenManagedKafkaCRType(OpenShiftClient oc, ManagedKafkaType mkType) {
         return listManagedKafka(oc, mkType)
             .stream()
-            .filter(e -> !e.getMetadata().getName().equals(getReservedDeploymentName(mkType)))
+            .filter(e -> !e.getMetadata().getName().contains(getReservedDeploymentPrefix(mkType)))
             .mapToInt(FleetshardUtils::getStreamingUnitOfMkInstance)
             .sum();
     }
@@ -75,8 +75,8 @@ public class FleetshardUtils {
             .collect(Collectors.toMap(m -> m.getMetadata().getName(), m -> m.getStatus().getReadyReplicas()));
     }
 
-    public static String getReservedDeploymentName(ManagedKafkaType managedKafkaType) {
-        return String.format("reserved-kafka-%s-1", managedKafkaType);
+    public static String getReservedDeploymentPrefix(ManagedKafkaType managedKafkaType) {
+        return String.format("reserved-kafka-%s-", managedKafkaType);
     }
 
 }


### PR DESCRIPTION
new version of test is faster and run for both standard and developer instances. 
It does not create kafka instance and instead simply observe that SU, and reported capacity are aligned. 
In case of unexpected trafic (new kafka being created while waiting for freeing of capacity, or old kafka being deleted while waiting for capacity being taken) test is skipped. Otherwise it waits for 6 minutes for values to match each other